### PR TITLE
46 repeat and abundance

### DIFF
--- a/docs/source/appendices/design_decisions.rst
+++ b/docs/source/appendices/design_decisions.rst
@@ -8,7 +8,7 @@ specification. As these trade-offs may not be apparent to outside
 readers, this section highlights the most significant ones and the
 rationale for our design decisions, including:
 
-.. _use-variation:
+.. _variation-not-variant:
 
 Variation Rather than Variant
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@ -24,7 +24,7 @@ and transcript abundance. Capturing these other classes of variation
 is a :doc:`future goal <future_plans>` of VRS, as there are many
 annotations that will require these variation classes as the subject.
 
-.. _use-allele:
+.. _allele-not-variant:
 
 Allele Rather than Variant
 @@@@@@@@@@@@@@@@@@@@@@@@@@

--- a/docs/source/impl-guide/example.rst
+++ b/docs/source/impl-guide/example.rst
@@ -84,13 +84,13 @@ The interval is then 'placed' on a sequence to create the
       "type": "SequenceLocation"
     }
 
-A :ref:`sequence-state` objects consists simply of the replacement sequence, as follows:
+A :ref:`LiteralSequence` object consists simply of the replacement sequence, as follows:
 
 .. code-block:: json
 
     {
       "sequence": "C",
-      "type": "SequenceState"
+      "type": "LiteralSequence"
     }
 
 We are now in a position to construct an :ref:`allele` object using
@@ -110,7 +110,7 @@ the objects defined above:
       },
       "state": {
         "sequence": "C",
-        "type": "SequenceState"
+        "type": "LiteralSequence"
       },
       "type": "Allele"
     }

--- a/docs/source/style.rst
+++ b/docs/source/style.rst
@@ -36,24 +36,47 @@ For example::
 
 To aid comprehension, the Text Styles section source looks like this::
 
-    .. _text-styles:
+    .. _text-styles-target:
     
     Text Styles
     !!!!!!!!!!!
 
 
-.. _text-styles:
+.. _text-styles-target:
 
 Text Styles
 !!!!!!!!!!!
 
-* Literal strings. Use double backticks. Example: ````a literal````
-  renders as ``a literal``. 
+A cheat sheet for making references, links, and literals in sphinx.
 
-* Use `.. _refname:` to create a target, and use ``:ref:`refname``` to
-  reference it.  Use this method for all headings, like in this
-  document for :ref:`text-styles` (and see source code excerpt above).
+* For external links, use ``target_``.
 
-* Classes: Use ref. Example: ``:ref:`Allele``` renders as :ref:`Allele`.
+  * See ``epilog.rst`` for pre-defined links.
+  * e.g, ``Base64_`` renders as Base64_ and ```Compact URI (CURIE)`_``
+    renders as `Compact URI (CURIE)`_.
 
-* Attributes and variables. Use \*. Example: ``*attribute*`` renders as *attribute*.
+* *Within* VRS documentation, use ``.. _refname:`` to create link
+  target, and use ``:ref:`refname``` to reference it.
+
+  * Create explicit link targets for all headings.
+  * Do not rely on the implicit targets created by sphinx because
+    changing the heading will break the link.
+  * e.g., ``:ref:`text-styles-target``` renders as
+    :ref:`text-styles-target` and uses the heading text as
+    the link name.
+  * e.g., ``:ref:`Alleles <Allele>``` renders as :ref:`Alleles
+    <Allele>`, with custom link text.
+  * Use class names verbatim when making link targets (e.g.,
+    ``.. _SequenceLocation:``). Use (lowercase) kebab-case for other
+    sections (e.g., ``.. computed-identifiers:``).
+
+* Use \* for attributes.
+
+  * ``*attribute*`` renders as *attribute*.
+  * e.g., The :ref:`Allele` *location* attribute must be set.
+
+* Use double backticks for literals.
+
+  * ````literal```` renders as ``literal``
+  * e.g., The :ref:`Allele` *type* attribute must be set to ``"Allele"``.
+

--- a/docs/source/style.rst
+++ b/docs/source/style.rst
@@ -34,11 +34,25 @@ For example::
   !!!!!!!!!!!!!!!
 
 
+To aid comprehension, the Text Styles section source looks like this::
+
+    .. _text-styles:
+    
+    Text Styles
+    !!!!!!!!!!!
+
+
+.. _text-styles:
+
 Text Styles
 !!!!!!!!!!!
 
 * Literal strings. Use double backticks. Example: ````a literal````
   renders as ``a literal``. 
+
+* Use `.. _refname:` to create a target, and use ``:ref:`refname``` to
+  reference it.  Use this method for all headings, like in this
+  document for :ref:`text-styles` (and see source code excerpt above).
 
 * Classes: Use ref. Example: ``:ref:`Allele``` renders as :ref:`Allele`.
 

--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -414,7 +414,7 @@ $$$$$$$$$$$$$$$$$
 **Biological Definition**
 
 AbsoluteAbundance is the absolute and quantified amount of an entity
-within a genome, cell, or sample.
+within a system, such as a genome, cell, or sample.
 
 **Computational Definition**
 

--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -418,7 +418,7 @@ within a genome, cell, or sample.
 
 **Computational Definition**
 
-AbsoluteAbundance is represented as a `subject`, which may be an
+AbsoluteAbundance references a `subject`, which may be an
 Allele or Haplotype, or any object identifiable with a CURIE.
 
 **Information Model**

--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -1,3 +1,9 @@
+.. todo:: Review enums for consistency of presentation in the
+          information model.
+.. todo:: standardize ````_ v. :ref:````
+
+
+
 Terminology & Information Model
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -49,166 +55,68 @@ depend only on previously-defined terms.
 Information Model Principles
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
-* VRS uses `snake_case
-  <https://simple.wikipedia.org/wiki/Snake_case>`__ to represent
-  compound words.  Although the schema is currently JSON-based (which
+* **VRS uses** `snake_case
+  <https://simple.wikipedia.org/wiki/Snake_case>`__ **to represent
+  compound words.** Although the schema is currently JSON-based (which
   would typically use camelCase), VRS itself is intended to be neutral
   with respect to languages and database.
 
-* VRS objects are `value objects
-  <https://en.wikipedia.org/wiki/Value_object>`__.  Two objects are
+* **VRS objects are minimal** `value objects
+  <https://en.wikipedia.org/wiki/Value_object>`__. Two objects are
   considered equal if and only if their respective attributes are
-  equal.  As value objects, VRS objects are used as primitive types and
-  SHOULD NOT be used as containers for related data.  Instead, related
-  data should be associated with VRS objects through identifiers.  See
-  :ref:`computed-identifiers`.
+  equal.  As value objects, VRS objects are used as primitive types
+  and MUST NOT be used as containers for related data, such as primary
+  database accessions, representations in particular formats, or links
+  to external data.  Instead, related data should be associated with
+  VRS objects through identifiers.  See :ref:`computed-identifiers`.
 
-* Error handling is intentionally unspecified and delegated to
-  implementation.  VRS provides foundational data types that
+* **Error handling is intentionally unspecified and delegated to
+  implementation.**  VRS provides foundational data types that
   enable significant flexibility.  Except where required by this
   specification, implementations may choose whether and how to
   validate data.  For example, implementations MAY choose to validate
   that particular combinations of objects are compatible, but such
   validation is not required.
 
-* We recognize that a common desire may be to have human-readable
-  identifiers associated with VRS objects. We recommend using the _id
-  field (see :ref:`optional-attributes` below) to create a lookup for
-  any such identifiers (see :ref:`example usage
-  <associating-annotations>`), and provide reference methods for
-  creating VRS identifiers from other common variant formats (see the
-  :ref:`HGVS translation example <example>`).
+* **Optional attributes start with an underscore.** Optional
+  attributes are not part of the value object.  Such attributes are
+  not considered when evaluating equality or creating computed
+  identifiers.  The `_id` attribute is available to identifiable
+  objects, and MAY be used by an implementation to store the
+  identifier for a VRS object.  If used, the stored `_id` element MUST
+  be a `CURIE`_. If used for creating a :ref:`truncated-digest`
+  for parent objects, the stored element must be a :ref:`GA4GH
+  Computed Identifier <identify>`.  Implementations MUST ignore
+  attributes beginning with an underscore and they SHOULD NOT transmit
+  objects containing them.
 
 
-.. _optional-attributes:
 
-Optional Attributes
-@@@@@@@@@@@@@@@@@@@
+.. _SequenceExpression:
 
-* VRS attributes use a leading underscore to represent optional
-  attributes that are not part of the value object.  Such attributes
-  are not considered when evaluating equality or creating computed
-  identifiers. Currently, the only such attribute in the specification
-  is the `_id` attribute.
-
-* The `_id` attribute is available to identifiable objects, and MAY be
-  used by an implementation to store the identifier for a VRS object.
-  If used, the stored `_id` element MUST be a :ref:`curie`. If used for
-  creating a :ref:`truncated-digest` for parent objects, the stored
-  element must be a :ref:`GA4GH Computed Identifier <identify>`.
-
-
-Primitive Concepts
+SequenceExpression
 @@@@@@@@@@@@@@@@@@
 
+VRS provides several mechanisms to describe a sequence change,
+collectively referred to as SequenceExpressions. They are:
 
-.. _curie:
-
-CURIE
-#####
-
-**Computational Definition**
-
-A `CURIE <https://www.w3.org/TR/curie/>`__ formatted string.  A CURIE
-string has the structure ``prefix``:``reference`` (W3C Terminology).
-
-**Implementation Guidance**
-
-* All identifiers in VRS MUST be a valid |curie|, regardless of
-  whether the identifier refers to GA4GH VRS objects or external data.
-* For GA4GH VRS objects, this specification RECOMMENDS using globally
-  unique :ref:`computed-identifiers` for use within *and* between
-  systems.
-* For external data, CURIE-formatted identifiers MUST be used.  When
-  an appropriate namespace exists at `identifiers.org
-  <http://identifiers.org/>`__, that namespace MUST be used.  When an
-  appropriate namespace does not exist at `identifiers.org
-  <http://identifiers.org/>`__, support is implementation-dependent.
-  That is, implementations MAY choose whether and how to support
-  informal or local namespaces.
-* Implementations MUST use CURIE identifiers verbatim. Implementations
-  MAY NOT modify CURIEs in any way (e.g., case-folding).
+* :ref:`LiteralSequence`: A class that wraps a :ref:`Sequence`
+  specified as a string.
+* :ref:`derived-sequence`: A sequence that is derived from a sequence
+  location, possibly with transformation.
+* :ref:`repeated-sequence`: A description of a repeating element,
+  possibly with ambiguity.
 
 
-**Examples**
+.. _LiteralSequence:
 
-Identifiers for GRCh38 chromosome 19::
-
-    ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
-    refseq:NC_000019.10
-    grch38:19
-
-See :ref:`identify` for examples of CURIE-based identifiers for VRS
-objects.
-
-
-.. _residue:
-
-Residue
-#######
-
-**Biological Definition**
-
-A residue refers to a specific `monomer`_ within the `polymeric
-chain`_ of a `protein`_ or `nucleic acid`_ (Source: `Wikipedia Residue
-page`_).
+LiteralSequence
+###############
 
 **Computational Definition**
 
-A character representing a specific residue (i.e., molecular species)
-or groupings of these ("ambiguity codes"), using `one-letter IUPAC
-abbreviations <https://www.genome.jp/kegg/catalog/codes1.html>`_ for
-nucleic acids and amino acids.
-
-
-.. _sequence:
-
-Sequence
-########
-
-**Biological Definition**
-
-A contiguous, linear polymer of nucleic acid or amino acid residues.
-
-**Computational Definition**
-
-A character string of :ref:`Residues <Residue>` that represents a
-biological sequence using the conventional sequence order (5'-to-3'
-for nucleic acid sequences, and amino-to-carboxyl for amino acid
-sequences). IUPAC ambiguity codes are permitted in Sequences.
-
-**Information Model**
-
-A Sequence is a string, constrained to contain only characters representing IUPAC nucleic acid or
-amino acid codes.
-
-**Implementation Guidance**
-
-* Sequences MAY be empty (zero-length) strings. Empty sequences are used as the
-  replacement Sequence for deletion Alleles.
-* Sequences MUST consist of only uppercase IUPAC abbreviations, including ambiguity codes.
-* A Sequence provides a stable coordinate system by which an :ref:`Allele` MAY be located and
-  interpreted.
-* A Sequence MAY have several roles. A “reference sequence” is any Sequence used
-  to define an :ref:`Allele`. A Sequence that replaces another Sequence is
-  called a “replacement sequence”.
-* In some contexts outside VRS, “reference sequence” may refer
-  to a member of set of sequences that comprise a genome assembly. In the VRS
-  specification, any sequence may be a “reference sequence”, including those in
-  a genome assembly.
-* For the purposes of representing sequence variation, it is not
-  necessary that Sequences be explicitly “typed” (i.e., DNA, RNA, or
-  AA).
-
-
-.. _integerrange:
-
-IntegerRange
-############
-
-**Computational Definition**
-
-An pair of integer values used to specify an inclusive range.
+A LiteralSequence "wraps" a string representation of a sequence for
+parallelism with other SequenceExpressions.
 
 **Information Model**
 
@@ -225,37 +133,116 @@ An pair of integer values used to specify an inclusive range.
    * - type
      - string
      - 1..1
-     - MUST be "IntegerRange"
-   * - min
-     - int
-     - 0..1
-     - minimum value; inclusive
-   * - end
-     - int
-     - 0..1
-     - maximum value; inclusive
+     - MUST be "LiteralSequence"
+   * - :ref:`Sequence`
+     - string
+     - 1..1
+     - The string representation of the sequence
 
 **Implementation Guidance**
 
-* At least one of min or max must be specified.
-
-**Examples**
-
-.. parsed-literal::
-
-   {
-     "max": 10,
-     "min": 5
-   }
+* Why wrap...
 
 
-Non-variation classes
-@@@@@@@@@@@@@@@@@@@@@@
+.. _derived-sequence:
+
+DerivedSequence
+###############
+
+**Biological Definition**
+
+Certain mechanisms of variation result from relocating and
+transforming sequence from another location in the genome.
+
+**Computational Definition**
+
+A relocated sequence is specified by the location of the source
+material and the orientation of that sequence.
+
+**Information Model**
+
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - type
+     - string
+     - 1..1
+     - MUST be "DerivedSequence"
+   * - location
+     - :ref:`SequenceLocation`
+     - 1..1
+     - The location from which the source subsequence is obtained
+   * - transformation
+     - string; enum
+     - 1..1
+     - One of: "none", "reverse", "complement", "reverse-complement"
+
+**Implementation Guidance**
+
+* TODO
+
+
+.. _repeated-sequence:
+
+RepeatedSequence
+################
+
+**Biological Definition**
+
+A contiguous, tandem repeat of a sequence.
+
+**Computational Definition**
+
+A RepeatedSequence is comprised of a `sequence`, specified as a
+SequenceExpression, and a `count` object, which specifies the `min`
+and `max` number of repeats.
+
+**Information Model**
+
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - type
+     - string
+     - 1..1
+     - MUST be "XXX"
+   * - sequence
+     - :ref:`SequenceExpression`
+     - 1..1
+     - ...
+   * - count
+     - :ref:`IntegerRange`
+     - 1..1
+     - ...
+
+**Implementation Guidance**
+
+* At least one of ``count.min`` or ``count.max`` must be specified.
+* If both `count.min` and `count.max` are specified, then they must
+  satisfy ``0 <= count.min <= count.max``.
+
+
+Locations and Intervals
+@@@@@@@@@@@@@@@@@@@@@@@
 
 .. _interval:
 .. _sequenceinterval:
 
-SequenceInterval (Abstract Class)
+SequenceInterval
 #################################
 
 **Biological Definition**
@@ -496,7 +483,7 @@ A contiguous region specified by chromosomal bands features.
 
 .. _location:
 
-Location (Abstract Class)
+Location
 #########################
 
 **Biological Definition**
@@ -708,167 +695,6 @@ named :ref:`Sequence`.
 
 
 
-.. _gene:
-
-Gene
-$$$$
-
-
-**Biological Definition**
-
-Gene generally refers to a region of sequence that has some function.
-Gene is an elusive concept in biology with nuanced meaning that often
-depends on context, including whether the gene makes a transcripts,
-whether the transcript encodes a protein, non-functional ancestral
-elements ("pseudogenes").  In VRS, a gene is a reference to a
-third-party definition of a species-specific gene.
-
-**Computational definition**
-
-External gene definitions are referenced with a CURIE.
-
-**Information Model**
-
-.. list-table::
-   :class: reece-wrap
-   :header-rows: 1
-   :align: left
-   :widths: auto
-
-   * - Field
-     - Type
-     - Limits
-     - Description
-   * - _id
-     - :ref:`CURIE`
-     - 0..1
-     - Location Id; MUST be unique within document
-   * - type
-     - string
-     - 1..1
-     - Location type; MUST be set to **`Gene`**
-
-**Implementation guidance**
-
-* Gene symbols (e.g., "BRCA1") are unreliable keys.  Implementations
-  MUST NOT use a gene symbol to define a Gene.
-* A gene is specific to a species.  Gene orthologs have distinct
-  records in the recommended databases.  For example, the BRCA1 gene
-  in humans and the Brca1 gene in mouse are orthologs and have
-  distinct records in the previously recommended gene databases.
-* The primary use case for Gene is as a subject of an abundance
-  statement statement.
-* Implementations MUST use gene namespaces available from
-  identifiers.org whenever possible.  Examples include:
-
-    * `hgnc <https://registry.identifiers.org/registry/hgnc>`__
-    * `ncbigene <https://registry.identifiers.org/registry/ncbigene>`__
-    * `ensembl <https://registry.identifiers.org/registry/ensembl>`__
-    * `vgnc <https://registry.identifiers.org/registry/vgnc>`__
-    * `mgi <https://registry.identifiers.org/registry/mgi>`__
-* Implementations SHOULD prefer the `hgnc` namespace for Human
-  variation in order to improve interoperability.
-* Gene MAY be converted to :ref:`sequence-location` using external
-  data. The source of such data and mechanism for implementation is
-  not defined by this specification.
-
-**Example**
-
-The following examples all refer to the Human BRCA1 gene:
-
-.. parsed-literal::
-
-   {
-     'gene': 'ncbigene:672',
-     'type': 'Gene'
-   }
-
-   {
-     'gene': 'hgnc:1100',
-     'type': 'Gene'
-   }
-
-   {
-     'gene': 'ensembl:ENSG00000012048',
-     'type': 'Gene'
-   }
-
-
-**Sources**
-
-* `SequenceOntology: gene (SO:0000704)
-  <http://www.sequenceontology.org/browser/current_release/term/SO:0000704>`__
-  — A region (or regions) that includes all of the sequence elements
-  necessary to encode a functional transcript. A gene may include
-  regulatory regions, transcribed regions and/or other functional
-  sequence regions.
-
-
-.. _state:
-
-State (Abstract Class)
-######################
-
-**Biological Definition**
-
-None.
-
-**Computational Definition**
-
-*State* objects are one of two primary components specifying a VRS
-:ref:`Allele` (in addition to :ref:`Location`), and the designated
-components for representing change (or non-change) of the features
-indicated by the Allele Location. As an abstract class, State currently
-encompasses single and contiguous :ref:`sequence` changes (see :ref:`SequenceState
-<sequence-state>`), with additional types under consideration (see
-:ref:`planned-states`).
-
-.. _sequence-state:
-
-SequenceState
-$$$$$$$$$$$$$
-
-**Biological Definition**
-
-None.
-
-**Computational Definition**
-
-The *SequenceState* class specifically captures a :ref:`sequence` as a
-:ref:`State`. This is the State class to use for representing
-"ref-alt" style variation, including SNVs, MNVs, del, ins, and delins.
-
-**Information Model**
-
-.. list-table::
-   :class: reece-wrap
-   :header-rows: 1
-   :align: left
-   :widths: auto
-
-   * - Field
-     - Type
-     - Limits
-     - Description
-   * - type
-     - string
-     - 1..1
-     - MUST be "SequenceState"
-   * - sequence
-     - string
-     - 1..1
-     - The string of sequence residues that is to be used as the state for other types.
-
-**Examples**
-
-.. parsed-literal::
-
-    {
-      "sequence": "T",
-      "type": "SequenceState"
-    }
-
-
 .. _variation:
 
 Variation
@@ -895,16 +721,16 @@ subclass defined by the VRS |version| specification is the
 Variations that are not yet covered.
 
 
-.. _molecularvariation:
+.. _MolecularVariation:
 
-MolecularVariation
-@@@@@@@@@@@@@@@@@@
+Molecular Variation
+###################
 
 
 .. _allele:
 
 Allele
-######
+$$$$$$
 
 **Biological Definition**
 
@@ -944,27 +770,27 @@ sequence at a :ref:`Location <Location>`.
      - 1..1
      - Where Allele is located
    * - state
-     - :ref:`State`
+     - :ref:`SequenceExpression` | :ref:`SequenceState`
      - 1..1
-     - State at location
+     - A description of the sequence change or expression
 
 **Implementation Guidance**
 
-* The :ref:`State <State>` and :ref:`Location <Location>` subclasses
-  respectively represent diverse kinds of sequence changes and
-  mechanisms for describing the locations of those changes, including
-  varying levels of precision of sequence location and categories of
-  sequence changes.
+* The :ref:`SequenceState <SequenceState>` and :ref:`Location
+  <Location>` subclasses respectively represent diverse kinds of
+  sequence changes and mechanisms for describing the locations of
+  those changes, including varying levels of precision of sequence
+  location and categories of sequence changes.
 * Implementations MUST enforce values interval.end ≤ sequence_length
   when the Sequence length is known.
 * Alleles are equal only if the component fields are equal: at the
   same location and with the same state.
 * Alleles MAY have multiple related representations on the same
   Sequence type due to normalization differences.
-* Implementations SHOULD normalize Alleles using :ref:`"justified"
+* Implementations SHOULD normalize Alleles using :ref:`fully-justified
   normalization <normalization>` whenever possible to facilitate
   comparisons of variation in regions of representational ambiguity.
-* Implementations MUST normalize Alleles using :ref:`"justified"
+* Implementations MUST normalize Alleles using :ref:`fully-justified
   normalization <normalization>` when generating a
   :ref:`computed-identifiers`.
 * When the alternate Sequence is the same length as the interval, the
@@ -1055,7 +881,7 @@ sequence at a :ref:`Location <Location>`.
 .. _haplotype:
 
 Haplotype
-#########
+$$$$$$$$$
 
 **Biological Definition**
 
@@ -1185,14 +1011,14 @@ order. See :ref:`computed-identifiers` for more information.
 
 
 
-.. _systemicvariation:
+.. _systemic-variation:
 
-SystemicVariation
-@@@@@@@@@@@@@@@@@
+Systemic Variation
+##################
 
 
 AbsoluteAbundance
-#################
+$$$$$$$$$$$$$$$$$
 
 **Biological Definition**
 
@@ -1229,7 +1055,7 @@ Allele or Haplotype, or any object identifiable with a CURIE.
      - 1..1
      - Subject of the relative abundance statement
    * - amount
-     - :ref:`IntegerRange`
+     - `IntegerRange`
      - 1..1
      - At least one of `amount.min` or `amount.max` must be specified
 
@@ -1249,7 +1075,7 @@ Allele or Haplotype, or any object identifiable with a CURIE.
 
 
 RelativeAbundance
-#################
+$$$$$$$$$$$$$$$$$$
 
 **Biological Definition**
 
@@ -1303,13 +1129,13 @@ and a qualitative relative amount.
 
 .. _othervariation:
 
-OtherVariation
-@@@@@@@@@@@@@@
+Other Variation
+################
 
 .. _text:
 
 Text
-####
+$$$$
 
 **Biological Definition**
 
@@ -1375,8 +1201,10 @@ text.
     }
 
 
+.. _variation-set:
+
 VariationSet
-############
+$$$$$$$$$$$$
 
 **Biological Definition**
 
@@ -1512,3 +1340,341 @@ The GA4GH computed identifier for these sets is
 `ga4gh:VS.WVC_R7OJ688EQX3NrgpJfsf_ctQUsVP3`, regardless of the whether
 the Variation objects are inlined or referenced, and regardless of
 order. See :ref:`computed-identifiers` for more information.
+
+
+Primitive Concepts
+@@@@@@@@@@@@@@@@@@
+
+
+.. _curie:
+
+CURIE
+#####
+
+**Computational Definition**
+
+A `CURIE <https://www.w3.org/TR/curie/>`__ formatted string.  A CURIE
+string has the structure ``prefix``:``reference`` (W3C Terminology).
+
+**Implementation Guidance**
+
+* All identifiers in VRS MUST be a valid |curie|, regardless of
+  whether the identifier refers to GA4GH VRS objects or external data.
+* For GA4GH VRS objects, this specification RECOMMENDS using globally
+  unique :ref:`computed-identifiers` for use within *and* between
+  systems.
+* For external data, CURIE-formatted identifiers MUST be used.  When
+  an appropriate namespace exists at `identifiers.org
+  <http://identifiers.org/>`__, that namespace MUST be used.  When an
+  appropriate namespace does not exist at `identifiers.org
+  <http://identifiers.org/>`__, support is implementation-dependent.
+  That is, implementations MAY choose whether and how to support
+  informal or local namespaces.
+* Implementations MUST use CURIE identifiers verbatim. Implementations
+  MAY NOT modify CURIEs in any way (e.g., case-folding).
+
+
+**Examples**
+
+Identifiers for GRCh38 chromosome 19::
+
+    ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
+    refseq:NC_000019.10
+    grch38:19
+
+See :ref:`identify` for examples of CURIE-based identifiers for VRS
+objects.
+
+
+.. _gene:
+
+Gene
+####
+
+.. todo:: Verify that we really want to include Gene as a class. Reece
+          still thinks this is useless and perhaps detrimental.
+
+**Biological Definition**
+
+Gene generally refers to a region of sequence that has some function.
+Gene is an elusive concept in biology with nuanced meaning that often
+depends on context, including whether the gene makes a transcripts,
+whether the transcript encodes a protein, non-functional ancestral
+elements ("pseudogenes").  In VRS, a gene is a reference to a
+third-party definition of a species-specific gene.
+
+**Computational definition**
+
+External gene definitions are referenced with a CURIE.
+
+**Information Model**
+
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - _id
+     - :ref:`CURIE`
+     - 0..1
+     - Location Id; MUST be unique within document
+   * - type
+     - string
+     - 1..1
+     - Location type; MUST be set to **`Gene`**
+
+**Implementation guidance**
+
+* Gene symbols (e.g., "BRCA1") are unreliable keys.  Implementations
+  MUST NOT use a gene symbol to define a Gene.
+* A gene is specific to a species.  Gene orthologs have distinct
+  records in the recommended databases.  For example, the BRCA1 gene
+  in humans and the Brca1 gene in mouse are orthologs and have
+  distinct records in the previously recommended gene databases.
+* The primary use case for Gene is as a subject of an abundance
+  statement statement.
+* Implementations MUST use gene namespaces available from
+  identifiers.org whenever possible.  Examples include:
+
+    * `hgnc <https://registry.identifiers.org/registry/hgnc>`__
+    * `ncbigene <https://registry.identifiers.org/registry/ncbigene>`__
+    * `ensembl <https://registry.identifiers.org/registry/ensembl>`__
+    * `vgnc <https://registry.identifiers.org/registry/vgnc>`__
+    * `mgi <https://registry.identifiers.org/registry/mgi>`__
+* Implementations SHOULD prefer the `hgnc` namespace for Human
+  variation in order to improve interoperability.
+* Gene MAY be converted to :ref:`sequence-location` using external
+  data. The source of such data and mechanism for implementation is
+  not defined by this specification.
+
+**Example**
+
+The following examples all refer to the Human BRCA1 gene:
+
+.. parsed-literal::
+
+   {
+     'gene': 'ncbigene:672',
+     'type': 'Gene'
+   }
+
+   {
+     'gene': 'hgnc:1100',
+     'type': 'Gene'
+   }
+
+   {
+     'gene': 'ensembl:ENSG00000012048',
+     'type': 'Gene'
+   }
+
+
+**Sources**
+
+* `SequenceOntology: gene (SO:0000704)
+  <http://www.sequenceontology.org/browser/current_release/term/SO:0000704>`__
+  — A region (or regions) that includes all of the sequence elements
+  necessary to encode a functional transcript. A gene may include
+  regulatory regions, transcribed regions and/or other functional
+  sequence regions.
+
+
+
+.. _IntegerRange:
+
+IntegerRange
+############
+
+**Computational Definition**
+
+An pair of integer values used to specify an inclusive range.
+
+**Information Model**
+
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - type
+     - string
+     - 1..1
+     - MUST be "IntegerRange"
+   * - min
+     - int
+     - 0..1
+     - minimum value; inclusive
+   * - end
+     - int
+     - 0..1
+     - maximum value; inclusive
+
+**Implementation Guidance**
+
+* At least one of min or max must be specified.
+
+**Examples**
+
+.. parsed-literal::
+
+   {
+     "max": 10,
+     "min": 5
+   }
+
+
+.. _Residue:
+
+Residue
+#######
+
+**Biological Definition**
+
+A residue refers to a specific `monomer`_ within the `polymeric
+chain`_ of a `protein`_ or `nucleic acid`_ (Source: `Wikipedia Residue
+page`_).
+
+**Computational Definition**
+
+A character representing a specific residue (i.e., molecular species)
+or groupings of these ("ambiguity codes"), using `one-letter IUPAC
+abbreviations <https://www.genome.jp/kegg/catalog/codes1.html>`_ for
+nucleic acids and amino acids.
+
+
+.. _Sequence:
+
+Sequence
+########
+
+**Biological Definition**
+
+A contiguous, linear polymer of nucleic acid or amino acid residues.
+
+**Computational Definition**
+
+A character string of :ref:`Residues <Residue>` that represents a
+biological sequence using the conventional sequence order (5'-to-3'
+for nucleic acid sequences, and amino-to-carboxyl for amino acid
+sequences). IUPAC ambiguity codes are permitted in Sequences.
+
+**Information Model**
+
+A Sequence is a string, constrained to contain only characters representing IUPAC nucleic acid or
+amino acid codes.
+
+**Implementation Guidance**
+
+* Sequences MAY be empty (zero-length) strings. Empty sequences are used as the
+  replacement Sequence for deletion Alleles.
+* Sequences MUST consist of only uppercase IUPAC abbreviations, including ambiguity codes.
+* A Sequence provides a stable coordinate system by which an :ref:`Allele` MAY be located and
+  interpreted.
+* A Sequence MAY have several roles. A “reference sequence” is any Sequence used
+  to define an :ref:`Allele`. A Sequence that replaces another Sequence is
+  called a “replacement sequence”.
+* In some contexts outside VRS, “reference sequence” may refer
+  to a member of set of sequences that comprise a genome assembly. In the VRS
+  specification, any sequence may be a “reference sequence”, including those in
+  a genome assembly.
+* For the purposes of representing sequence variation, it is not
+  necessary that Sequences be explicitly “typed” (i.e., DNA, RNA, or
+  AA).
+
+
+Deprecated Classes
+@@@@@@@@@@@@@@@@@@
+
+.. _sequence-state:
+
+SequenceState
+#############
+
+.. warning::
+
+   SequenceState is deprecated. It will be removed in VRS 2.0. Use
+   :ref:`LiteralSequence` instead.
+
+**Biological Definition**
+
+None.
+
+**Computational Definition**
+
+The *SequenceState* class specifically captures a :ref:`sequence` as a
+:ref:`State`. This is the State class to use for representing
+"ref-alt" style variation, including SNVs, MNVs, del, ins, and delins.
+
+**Information Model**
+
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - type
+     - string
+     - 1..1
+     - MUST be "SequenceState"
+   * - sequence
+     - string
+     - 1..1
+     - The string of sequence residues that is to be used as the state for other types.
+
+**Examples**
+
+.. parsed-literal::
+
+    {
+      "sequence": "T",
+      "type": "SequenceState"
+    }
+
+
+Obsolete Classes
+@@@@@@@@@@@@@@@@
+
+.. _state:
+
+State
+#####
+
+.. Warning::
+
+   State is obsolete. It was previously an abstract class that was
+   intended for future growth. It was replaced by SequenceExpressions
+   with a superset of the the functionality envisioned for State.
+   Because State was abstract, and therefore never instantiated, it
+   was made obsolete at the same time that SequenceState was
+   deprecated.
+
+
+**Biological Definition**
+
+None.
+
+**Computational Definition**
+
+*State* objects are one of two primary components specifying a VRS
+:ref:`Allele` (in addition to :ref:`Location`), and the designated
+components for representing change (or non-change) of the features
+indicated by the Allele Location. As an abstract class, State currently
+encompasses single and contiguous :ref:`sequence` changes (see :ref:`SequenceState
+<sequence-state>`), with additional types under consideration (see
+:ref:`planned-states`).
+

--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -442,13 +442,18 @@ Allele or Haplotype, or any object identifiable with a CURIE.
      - 1..1
      - MUST be "AbsoluteAbundance"
    * - subject
-     - :ref:`Allele` | :ref:`Haplotype` | :ref:`CURIE`
+     - :ref:`MolecularVariation` | :ref:`CURIE`
      - 1..1
      - Subject of the abundance statement
    * - amount
      - `IntegerRange`
      - 1..1
-     - At least one of `amount.min` or `amount.max` must be specified
+     - The inclusive range of integral copies of the subject.
+
+**Implementation Guidance**
+
+* See :ref:`IntegerRange` for an interpretation of the ``amount``
+  attribute.
 
 **Example**
 
@@ -499,7 +504,7 @@ and a qualitative relative amount.
      - 1..1
      - MUST be "RelativeAbundance"
    * - subject
-     - :ref:`MolecularVariation` | :ref:`Gene`
+     - :ref:`MolecularVariation` | :ref:`CURIE`
      - 1..1
      - Subject of the abundance statement
    * - amount
@@ -1327,11 +1332,8 @@ and `max` number of repeats.
 
 **Implementation Guidance**
 
-* At least one of ``count.min`` or ``count.max`` must be specified.
-* If both `count.min` and `count.max` are specified, then they must
-  satisfy ``0 <= count.min <= count.max``.
-
-
+* See :ref:`IntegerRange` for an interpretation of the ``count``
+  attribute.
 
 
 Primitive Concepts
@@ -1506,14 +1508,18 @@ An pair of integer values used to specify an inclusive range.
      - int
      - 0..1
      - minimum value; inclusive
-   * - end
+   * - max
      - int
      - 0..1
      - maximum value; inclusive
 
 **Implementation Guidance**
 
-* At least one of min or max must be specified.
+* At least one of ``min`` or ``max`` must be specified.
+* If both ``min`` and ``max`` are specified, they MUST satisfy ``min
+  <= max``.
+* If ``min == max``, then the range specifies a single integer amount.
+
 
 **Examples**
 

--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -471,7 +471,7 @@ Allele or Haplotype, or any object identifiable with a CURIE.
 
 
 RelativeAbundance
-$$$$$$$$$$$$$$$$$$
+$$$$$$$$$$$$$$$$$
 
 **Biological Definition**
 
@@ -1671,4 +1671,3 @@ indicated by the Allele Location. As an abstract class, State
 currently encompasses single and contiguous :ref:`sequence` changes
 (see :ref:`SequenceState`), with additional types under consideration
 (see :ref:`planned-states`).
-

--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -98,21 +98,6 @@ Optional Attributes
   element must be a :ref:`GA4GH Computed Identifier <identify>`.
 
 
-Parking Lot
-@@@@@@@@@@@
-
-For abundance:
-##############
-
-Notes::
-
-    * identify ambiguity in expressions like
-    NC_000001.10:g.15764951_15765010dup...
-    NC_000001.10:g.(?_15764951)_(15765010_?)dup...
-    ... and identify causes of ambiguity
-
-
-
 Primitive Concepts
 @@@@@@@@@@@@@@@@@@
 
@@ -215,6 +200,53 @@ amino acid codes.
   necessary that Sequences be explicitly “typed” (i.e., DNA, RNA, or
   AA).
 
+
+.. _integerrange:
+
+IntegerRange
+############
+
+**Computational Definition**
+
+An pair of integer values used to specify an inclusive range.
+
+**Information Model**
+
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - type
+     - string
+     - 1..1
+     - MUST be "IntegerRange"
+   * - min
+     - int
+     - 0..1
+     - minimum value; inclusive
+   * - end
+     - int
+     - 0..1
+     - maximum value; inclusive
+
+**Implementation Guidance**
+
+* At least one of min or max must be specified.
+
+**Examples**
+
+.. parsed-literal::
+
+   {
+     "max": 10,
+     "min": 5
+   }
 
 
 Non-variation classes
@@ -863,6 +895,12 @@ subclass defined by the VRS |version| specification is the
 Variations that are not yet covered.
 
 
+.. _molecularvariation:
+
+MolecularVariation
+@@@@@@@@@@@@@@@@@@
+
+
 .. _allele:
 
 Allele
@@ -1014,74 +1052,6 @@ sequence at a :ref:`Location <Location>`.
   'variant' sequence at a locus.
 
 
-.. _text:
-
-Text
-####
-
-**Biological Definition**
-
-None
-
-**Computational Definition**
-
-The *Text* subclass of :ref:`Variation` is intended to capture textual
-descriptions of variation that cannot be parsed by other Variation
-subclasses, but are still treated as variation.
-
-**Information Model**
-
-.. list-table::
-   :class: reece-wrap
-   :header-rows: 1
-   :align: left
-   :widths: auto
-
-   * - Field
-     - Type
-     - Limits
-     - Description
-   * - _id
-     - :ref:`CURIE`
-     - 0..1
-     - Variation Id; MUST be unique within document
-   * - type
-     - string
-     - 1..1
-     - MUST be "Text"
-   * - definition
-     - string
-     - 1..1
-     - The textual variation representation not parsable by other subclasses of Variation.
-
-**Implementation Guidance**
-
-* An implementation MUST represent Variation with subclasses other
-  than Text if possible.
-* An implementation SHOULD define or adopt conventions for defining
-  the strings stored in Text.definition.
-* If a future version of VRS is adopted by an implementation and
-  the new version enables defining existing Text objects under a
-  different Variation subclass, the implementation MUST construct a
-  new object under the other Variation subclass. In such a case, an
-  implementation SHOULD persist the original Text object and respond
-  to queries matching the Text object with the new object.
-* Additional Variation subclasses are continually under
-  consideration. Please open a `GitHub issue
-  <https://github.com/ga4gh/vrs/issues>`__ if you would like to
-  propose a Variation subclass to cover a needed variation
-  representation.
-
-**Examples**
-
-.. parsed-literal::
-
-    {
-      "definition": "APOE loss",
-      "type": "Text"
-    }
-
-
 .. _haplotype:
 
 Haplotype
@@ -1213,6 +1183,196 @@ The GA4GH computed identifier for these Haplotypes is
 the Variation objects are inlined or referenced, and regardless of
 order. See :ref:`computed-identifiers` for more information.
 
+
+
+.. _systemicvariation:
+
+SystemicVariation
+@@@@@@@@@@@@@@@@@
+
+
+AbsoluteAbundance
+#################
+
+**Biological Definition**
+
+AbsoluteAbundance is the absolute and quantified amount of an entity
+within a genome, cell, or sample.
+
+**Computational Definition**
+
+AbsoluteAbundance is represented as a `subject`, which may be an
+Allele or Haplotype, or any object identifiable with a CURIE.
+
+**Information Model**
+
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - _id
+     - :ref:`CURIE`
+     - 0..1
+     - Computed Identifier
+   * - type
+     - string
+     - 1..1
+     - MUST be "AbsoluteAbundance"
+   * - subject
+     - :ref:`Allele` | :ref:`Haplotype` | :ref:`CURIE`
+     - 1..1
+     - Subject of the relative abundance statement
+   * - amount
+     - :ref:`IntegerRange`
+     - 1..1
+     - At least one of `amount.min` or `amount.max` must be specified
+
+**Example**
+
+.. parsed-literal::
+
+    {
+      "amount": {
+        "max": 5,
+        "min": 0,
+        "type": "IntegerRange"
+      },
+      "subject": "ncbigene:1234",
+      "type": "AbsoluteAbundance"
+    }
+
+
+RelativeAbundance
+#################
+
+**Biological Definition**
+
+Relative abundance is the qualitative relative amount of a molecular
+species within a genome, cell, or sample.
+
+**Computational Definition**
+
+Relative abundance is represented as a combination of the `subject`
+and a qualitative relative amount.
+
+**Information Model**
+
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - _id
+     - :ref:`CURIE`
+     - 0..1
+     - Computed Identifier
+   * - type
+     - string
+     - 1..1
+     - MUST be "RelativeAbundance"
+   * - subject
+     - :ref:`MolecularVariation` | :ref:`Gene`
+     - 1..1
+     - Subject of the relative abundance statement
+   * - amount
+     - text; one of: "gt", "ge", "eq", "le", "lt"
+     - 1..1
+     - The amount of the subject with respect to an unspecified
+       reference; see Notes.
+
+**Example**
+
+.. parsed-literal::
+
+    {
+      "amount": "lt",
+      "subject": "ncbigene:1234",
+      "type": "RelativeAbundance"
+    }
+
+.. _othervariation:
+
+OtherVariation
+@@@@@@@@@@@@@@
+
+.. _text:
+
+Text
+####
+
+**Biological Definition**
+
+Some forms of variation are described with text that is interpretable
+only by humans.
+
+**Computational Definition**
+
+`Text` variation captures descriptions of variation as unparsed
+text.
+
+**Information Model**
+
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - _id
+     - :ref:`CURIE`
+     - 0..1
+     - Variation Id; MUST be unique within document
+   * - type
+     - string
+     - 1..1
+     - MUST be "Text"
+   * - definition
+     - string
+     - 1..1
+     - The textual variation representation not parsable by other subclasses of Variation.
+
+**Implementation Guidance**
+
+* An implementation MUST represent Variation with subclasses other
+  than Text if possible.
+* Because the Text type can be easily abused, implementations are NOT
+  REQUIRED to provide it.  If it is provided, implementations SHOULD
+  consider applying access controls.
+* If a future version of VRS is adopted by an implementation and
+  the new version enables defining existing Text objects under a
+  different Variation subclass, the implementation MUST construct a
+  new object under the other Variation subclass. In such a case, an
+  implementation SHOULD persist the original Text object and respond
+  to queries matching the Text object with the new object.
+* Additional Variation subclasses are continually under
+  consideration. Please open a `GitHub issue
+  <https://github.com/ga4gh/vrs/issues>`__ if you would like to
+  propose a Variation subclass to cover a needed variation
+  representation.
+
+**Examples**
+
+.. parsed-literal::
+
+    {
+      "definition": "APOE loss",
+      "type": "Text"
+    }
 
 
 VariationSet

--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -92,7 +92,12 @@ Variation
 @@@@@@@@@
 
 The Variation class is the conceptual root of all types of variation,
-both current and future.
+both current and future, and the *Variation* abstract class is the
+top-level object in the :ref:`vr-schema-diagram`. Types of variation
+are widely varied, and there are several :ref:`planned-variation`
+currently under consideration to capture this diversity. In VRS,
+Variation types are broadly categorized as a :ref:`MolecularVariation`,
+a :ref:`SystemicVariation`, or a :ref:`utility subclass <othervariation>`.
 
 **Biological Definition**
 
@@ -102,14 +107,7 @@ individuals.
 
 **Computational Definition**
 
-The *Variation* abstract class is the top-level object in the
-:ref:`vr-schema-diagram` and represents the concept of a molecular
-state. The representation and types of molecular states are widely
-varied, and there are several :ref:`planned-variation` currently under
-consideration to capture this diversity. The primary Variation
-subclass defined by the VRS |version| specification is the
-:ref:`Allele`, with the :ref:`text` subclass for capturing other
-Variations that are not yet covered.
+Variation is a representation of the state of one or more molecules.
 
 
 .. _MolecularVariation:
@@ -117,24 +115,34 @@ Variations that are not yet covered.
 Molecular Variation
 ###################
 
+Molecular Variation is a :ref:`variation` of a contiguous molecule.
 
 .. _allele:
 
 Allele
 $$$$$$
 
+.. note:: The terms *allele* and *variant* are often used interchangeably,
+   although this use may mask subtle distinctions made by some users.
+
+   * In the genetics community, *allele* may also refer to a
+     haplotype.
+   * *Allele* connotes a state whereas *variant* connotes a change
+     between states. This distinction makes it awkward to use *variant*
+     to represent a refrence-agreement state at a Sequence Location,
+     and was one of the factors that influenced the preference of
+     *Allele* over *Variant* as the primary subject of annotations.
+   * Read more: Using :ref:`allele-not-variant`.
+
 **Biological Definition**
 
 One of a number of alternative forms of the same gene or same genetic
 locus. In the context of biological sequences, “allele” refers to one
-of a set of specific changes within a :ref:`Sequence`. In the context
-of VRS, Allele refers to a Sequence or Sequence change with respect to
-a reference sequence, without regard to genes or other features.
+of a set of specific changes within a :ref:`Sequence`.
 
 **Computational Definition**
 
-An Allele is an assertion of the :ref:`State <State>` of a biological
-sequence at a :ref:`Location <Location>`.
+An Allele is the state of a molecule at a specified :ref:`Location`.
 
 **Information Model**
 
@@ -167,8 +175,8 @@ sequence at a :ref:`Location <Location>`.
 
 **Implementation Guidance**
 
-* The :ref:`SequenceState <SequenceState>` and :ref:`Location
-  <Location>` subclasses respectively represent diverse kinds of
+* The :ref:`SequenceExpression` and :ref:`Location`
+  subclasses respectively represent diverse kinds of
   sequence changes and mechanisms for describing the locations of
   those changes, including varying levels of precision of sequence
   location and categories of sequence changes.
@@ -182,7 +190,7 @@ sequence at a :ref:`Location <Location>`.
   normalization <normalization>` whenever possible to facilitate
   comparisons of variation in regions of representational ambiguity.
 * Implementations MUST normalize Alleles using :ref:`fully-justified
-  normalization <normalization>` when generating a
+  normalization <normalization>` when generating
   :ref:`computed-identifiers`.
 * When the alternate Sequence is the same length as the interval, the
   lengths of the reference Sequence and imputed Sequence are the
@@ -191,8 +199,8 @@ sequence at a :ref:`Location <Location>`.
   is shorter than the length of the interval, the imputed Sequence is
   shorter than the reference Sequence, and conversely for replacements
   that are larger than the interval.
-* When the replacement is ``""`` (the empty string), the Allele refers to
-  a deletion at this location.
+* When the state is a :ref:`LiteralSequence` of ``""`` (the empty
+  string), the Allele refers to a deletion at this location.
 * The Allele entity is based on Sequence and is intended to be used
   for intragenic and extragenic variation. Alleles are not explicitly
   associated with genes or other features.
@@ -204,22 +212,11 @@ sequence at a :ref:`Location <Location>`.
   the biological mechanism by which it was created. For instance, two
   non-adjacent single residue Alleles could be represented by a single
   contiguous multi-residue Allele.
-* The terms "allele" and "variant" are often used interchangeably,
-  although this use may mask subtle distinctions made by some users.
-
-   * In the genetics community, "allele" may also refer to a
-     haplotype.
-   * "Allele" connotes a state whereas "variant" connotes a change
-     between states. This distinction makes it awkward to use variant
-     to refer to the concept of an unchanged position in a Sequence
-     and was one of the factors that influenced the preference of
-     “Allele” over “Variant” as the primary subject of annotations.
-   * See :ref:`Use “Allele” rather than “Variant” <use-allele>` for
-     further details.
 * When a trait has a known genetic basis, it is typically represented
   computationally as an association with an Allele.
-* This specification's definition of Allele applies to all Sequence
-  types (DNA, RNA, AA).
+* This specification's definition of Allele applies to any
+  :ref:`Location`, including locations on RNA or protein
+  :ref:`Sequence`.
 
 **Examples**
 
@@ -402,7 +399,7 @@ order. See :ref:`computed-identifiers` for more information.
 
 
 
-.. _systemic-variation:
+.. _SystemicVariation:
 
 Systemic Variation
 ##################
@@ -525,7 +522,7 @@ and a qualitative relative amount.
     }
 
 
-.. _othervariation:
+.. _OtherVariation:
 
 Other Variation
 ################
@@ -1399,7 +1396,7 @@ Gene
 
 **Biological Definition**
 
-Gene generally refers to a region of sequence that has some function.
+Gene generally refers to a region of DNA that has some function.
 Gene is an elusive concept in biology with nuanced meaning that often
 depends on context, including whether the gene makes a transcripts,
 whether the transcript encodes a protein, non-functional ancestral

--- a/notebooks/develop.ipynb
+++ b/notebooks/develop.ipynb
@@ -530,38 +530,6 @@
       "{\n",
       "  \"amount\": \"lt\",\n",
       "  \"subject\": {\n",
-      "    \"gene_id\": \"ncbigene:1234\",\n",
-      "    \"type\": \"Gene\"\n",
-      "  },\n",
-      "  \"type\": \"RelativeAbundance\"\n",
-      "}\n"
-     ]
-    }
-   ],
-   "source": [
-    "ra = models.RelativeAbundance(\n",
-    "    subject=g,\n",
-    "    amount=\"lt\")\n",
-    "ppo(ra)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\n",
-      "  \"amount\": {\n",
-      "    \"max\": 5,\n",
-      "    \"min\": 0\n",
-      "  },\n",
-      "  \"subject\": {\n",
       "    \"location\": {\n",
       "      \"interval\": {\n",
       "        \"end\": 20,\n",
@@ -584,6 +552,36 @@
       "    },\n",
       "    \"type\": \"Allele\"\n",
       "  },\n",
+      "  \"type\": \"RelativeAbundance\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "ra = models.RelativeAbundance(\n",
+    "    subject=a,\n",
+    "    amount=\"lt\")\n",
+    "ppo(ra)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"amount\": {\n",
+      "    \"max\": 5,\n",
+      "    \"min\": 0,\n",
+      "    \"type\": \"IntegerRange\"\n",
+      "  },\n",
+      "  \"subject\": \"ncbigene:1234\",\n",
       "  \"type\": \"AbsoluteAbundance\"\n",
       "}\n"
      ]
@@ -591,9 +589,9 @@
    ],
    "source": [
     "aa = models.AbsoluteAbundance(\n",
-    "    subject=a,\n",
-    "    amount=models.Range(min=0, max=5))\n",
-    "ppo(aa)"
+    "    subject=g.gene_id,\n",
+    "    amount=models.IntegerRange(min=0, max=5))\n",
+    "ppo(vrs_enref(aa))"
    ]
   },
   {

--- a/notebooks/nbsupport
+++ b/notebooks/nbsupport
@@ -1,1 +1,1 @@
-../../notebooks/nbsupport
+../../../notebooks/nbsupport

--- a/schema/vrs.json
+++ b/schema/vrs.json
@@ -3,13 +3,13 @@
    "definitions": {
       "AbsoluteAbundance": {
          "additionalProperties": false,
-         "description": "Absolute abundance of a systemic subject such as a Gene or specific type of molecular variation.",
+         "description": "Absolute abundance of a systemic subject such as a gene or specific type of molecular variation.",
          "properties": {
             "_id": {
                "$ref": "#/definitions/CURIE"
             },
             "amount": {
-               "$ref": "#/definitions/Range"
+               "$ref": "#/definitions/IntegerRange"
             },
             "subject": {
                "oneOf": [
@@ -20,7 +20,7 @@
                      "$ref": "#/definitions/Haplotype"
                   },
                   {
-                     "$ref": "#/definitions/Gene"
+                     "$ref": "#/definitions/CURIE"
                   }
                ]
             },
@@ -72,19 +72,6 @@
                   "Allele"
                ],
                "type": "string"
-            }
-         },
-         "type": "object"
-      },
-      "BaseOffset": {
-         "additionalProperties": false,
-         "properties": {
-            "base": {
-               "type": "integer"
-            },
-            "offset": {
-               "default": 0,
-               "type": "integer"
             }
          },
          "type": "object"
@@ -198,9 +185,6 @@
          "additionalProperties": false,
          "description": "A reference to an external gene system, used as a location for variation.  Currently, the `ncbigene` namespace is required. See https://registry.identifiers.org/registry/ncbigene.",
          "properties": {
-            "_id": {
-               "$ref": "#/definitions/CURIE"
-            },
             "gene_id": {
                "$ref": "#/definitions/CURIE"
             },
@@ -246,6 +230,39 @@
          },
          "type": "object"
       },
+      "IntegerRange": {
+         "additionalProperties": false,
+         "description": "A (min,max) range of integer values. At least one of min or max must be specified.",
+         "example": {
+            "max": 10,
+            "min": 5,
+            "type": "IntegerRange"
+         },
+         "properties": {
+            "max": {
+               "default": null,
+               "type": [
+                  "integer",
+                  "null"
+               ]
+            },
+            "min": {
+               "default": null,
+               "type": [
+                  "integer",
+                  "null"
+               ]
+            },
+            "type": {
+               "default": "IntegerRange",
+               "enum": [
+                  "IntegerRange"
+               ],
+               "type": "string"
+            }
+         },
+         "type": "object"
+      },
       "LiteralSequence": {
          "additionalProperties": false,
          "properties": {
@@ -274,9 +291,6 @@
             },
             {
                "$ref": "#/definitions/SequenceLocation"
-            },
-            {
-               "$ref": "#/definitions/TranscriptLocation"
             }
          ]
       },
@@ -339,35 +353,9 @@
             }
          ]
       },
-      "Range": {
-         "additionalProperties": false,
-         "description": "A (min,max) range of integer values. At least one of min or max must be specified.",
-         "example": {
-            "end": 22,
-            "start": 11,
-            "type": "Range"
-         },
-         "properties": {
-            "max": {
-               "default": null,
-               "type": [
-                  "integer",
-                  "null"
-               ]
-            },
-            "min": {
-               "default": null,
-               "type": [
-                  "integer",
-                  "null"
-               ]
-            }
-         },
-         "type": "object"
-      },
       "RelativeAbundance": {
          "additionalProperties": false,
-         "description": "Relative abundance of a systemic subject such as a Gene or specific type of molecular variation.",
+         "description": "Relative abundance of a systemic subject such as a gene or specific type of molecular variation.",
          "properties": {
             "_id": {
                "$ref": "#/definitions/CURIE"
@@ -388,7 +376,7 @@
                      "$ref": "#/definitions/MolecularVariation"
                   },
                   {
-                     "$ref": "#/definitions/Gene"
+                     "$ref": "#/definitions/CURIE"
                   }
                ]
             },
@@ -594,141 +582,6 @@
                "default": "Text",
                "enum": [
                   "Text"
-               ],
-               "type": "string"
-            }
-         },
-         "type": "object"
-      },
-      "Transcript": {
-         "additionalProperties": false,
-         "description": "A specified subsequence within another sequence that is used as a reference sequence.",
-         "properties": {
-            "_id": {
-               "$ref": "#/definitions/CURIE"
-            },
-            "cds": {
-               "$ref": "#/definitions/SimpleInterval"
-            },
-            "exons": {
-               "items": {
-                  "$ref": "#/definitions/SimpleInterval"
-               },
-               "type": "array"
-            },
-            "sequence_id": {
-               "$ref": "#/definitions/CURIE"
-            },
-            "strand": {
-               "default": 1,
-               "enum": [
-                  1,
-                  -1
-               ],
-               "type": "integer"
-            },
-            "type": {
-               "default": "Transcript",
-               "enum": [
-                  "Transcript"
-               ],
-               "type": "string"
-            }
-         },
-         "type": "object"
-      },
-      "TranscriptFeature": {
-         "additionalProperties": false,
-         "properties": {
-            "feature_type": {
-               "enum": [
-                  "5'utr",
-                  "3'utr",
-                  "exon",
-                  "intron"
-               ],
-               "type": "string"
-            },
-            "index": {
-               "type": "integer"
-            }
-         },
-         "type": "object"
-      },
-      "TranscriptFeatureInterval": {
-         "additionalProperties": false,
-         "properties": {
-            "end": {
-               "$ref": "#/definitions/TranscriptFeature"
-            },
-            "start": {
-               "$ref": "#/definitions/TranscriptFeature"
-            },
-            "type": {
-               "default": "TranscriptFeatureInterval",
-               "enum": [
-                  "TranscriptFeatureInterval"
-               ],
-               "type": "string"
-            }
-         },
-         "type": "object"
-      },
-      "TranscriptInterval": {
-         "additionalProperties": false,
-         "properties": {
-            "end": {
-               "$ref": "#/definitions/BaseOffset"
-            },
-            "start": {
-               "$ref": "#/definitions/BaseOffset"
-            },
-            "type": {
-               "default": "TranscriptInterval",
-               "enum": [
-                  "TranscriptInterval"
-               ],
-               "type": "string"
-            }
-         },
-         "required": [
-            "type",
-            "start",
-            "end"
-         ],
-         "type": "object"
-      },
-      "TranscriptLocation": {
-         "additionalProperties": false,
-         "description": "A specified subsequence within another sequence that is used as a reference sequence.",
-         "properties": {
-            "_id": {
-               "$ref": "#/definitions/CURIE"
-            },
-            "interval": {
-               "oneOf": [
-                  {
-                     "$ref": "#/definitions/TranscriptInterval"
-                  },
-                  {
-                     "$ref": "#/definitions/TranscriptFeatureInterval"
-                  }
-               ]
-            },
-            "transcript": {
-               "oneOf": [
-                  {
-                     "$ref": "#/definitions/CURIE"
-                  },
-                  {
-                     "$ref": "#/definitions/Transcript"
-                  }
-               ]
-            },
-            "type": {
-               "default": "TranscriptLocation",
-               "enum": [
-                  "TranscriptLocation"
                ],
                "type": "string"
             }

--- a/schema/vrs.json
+++ b/schema/vrs.json
@@ -163,8 +163,9 @@
                "$ref": "#/definitions/SequenceLocation"
             },
             "transformation": {
-               "default": null,
+               "default": "none",
                "enum": [
+                  "none",
                   "reverse",
                   "complement",
                   "reverse-complement"
@@ -402,20 +403,7 @@
          },
          "properties": {
             "count": {
-               "additionalProperties": false,
-               "properties": {
-                  "max": {
-                     "type": [
-                        "integer",
-                        "null"
-                     ]
-                  },
-                  "min": {
-                     "minimum": 0,
-                     "type": "integer"
-                  }
-               },
-               "type": "object"
+               "$ref": "#/definitions/IntegerRange"
             },
             "sequence": {
                "$ref": "#/definitions/SequenceExpression"

--- a/schema/vrs.json
+++ b/schema/vrs.json
@@ -158,8 +158,6 @@
                "default": "none",
                "enum": [
                   "none",
-                  "reverse",
-                  "complement",
                   "reverse-complement"
                ],
                "type": "string"

--- a/schema/vrs.json
+++ b/schema/vrs.json
@@ -14,10 +14,7 @@
             "subject": {
                "oneOf": [
                   {
-                     "$ref": "#/definitions/Allele"
-                  },
-                  {
-                     "$ref": "#/definitions/Haplotype"
+                     "$ref": "#/definitions/MolecularVariation"
                   },
                   {
                      "$ref": "#/definitions/CURIE"
@@ -228,7 +225,7 @@
       },
       "IntegerRange": {
          "additionalProperties": false,
-         "description": "A (min,max) range of integer values. At least one of min or max must be specified.",
+         "description": "A [min,max] inclusive range of integer values. At least one of min or max must be specified.  An unspecified value indicates an unbounded min or max.  When both min and max are specified, they must satisfy min <= max.",
          "example": {
             "max": 10,
             "min": 5,

--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -188,7 +188,7 @@ definitions:
     additionalProperties: false
     type: object
     description: >-
-      Relative abundance of a systemic subject such as a gene or
+      Relative abundance of a systemic subject such as a Gene or
       specific type of molecular variation.
     properties:
       _id:
@@ -532,4 +532,3 @@ definitions:
     example:
       type: SequenceState
       sequence: C
-

--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -175,8 +175,7 @@ definitions:
         default: "AbsoluteAbundance"
       subject:
         oneOf:
-          - $ref: "#/definitions/Allele"
-          - $ref: "#/definitions/Haplotype"
+          - $ref: "#/definitions/MolecularVariation"
           - $ref: "#/definitions/CURIE"
       amount:
         $ref: "#/definitions/IntegerRange"
@@ -484,8 +483,10 @@ definitions:
 
   IntegerRange:
     description: >-
-      A (min,max) range of integer values. At least one of min or max
-      must be specified.
+      A [min,max] inclusive range of integer values. At least one of
+      min or max must be specified.  An unspecified value indicates an
+      unbounded min or max.  When both min and max are specified, they
+      must satisfy min <= max.
     additionalProperties: false
     type: object
     properties:

--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -79,8 +79,8 @@ definitions:
         $ref: "#/definitions/CURIE"
       type:
         type: string
-        enum: [Allele]
-        default: Allele
+        enum: ["Allele"]
+        default: "Allele"
       location:
         oneOf:
           - $ref: "#/definitions/CURIE"
@@ -126,8 +126,8 @@ definitions:
         $ref: "#/definitions/CURIE"
       type:
         type: string
-        enum: [Text]
-        default: Text
+        enum: ["Text"]
+        default: "Text"
       definition:
         type: string
         description: >-
@@ -171,8 +171,8 @@ definitions:
         $ref: "#/definitions/CURIE"
       type:
         type: string
-        enum: [AbsoluteAbundance]
-        default: AbsoluteAbundance
+        enum: ["AbsoluteAbundance"]
+        default: "AbsoluteAbundance"
       subject:
         oneOf:
           - $ref: "#/definitions/Allele"
@@ -196,8 +196,8 @@ definitions:
         $ref: "#/definitions/CURIE"
       type:
         type: string
-        enum: [RelativeAbundance]
-        default: RelativeAbundance
+        enum: ["RelativeAbundance"]
+        default: "RelativeAbundance"
       subject:
         oneOf:
           - $ref: "#/definitions/MolecularVariation"
@@ -228,8 +228,8 @@ definitions:
     properties:
       type:
         type: string
-        enum: [ChromosomeLocation]
-        default: ChromosomeLocation
+        enum: ["ChromosomeLocation"]
+        default: "ChromosomeLocation"
       _id:
         $ref: "#/definitions/CURIE"
       species_id:
@@ -297,8 +297,8 @@ definitions:
     properties:
       type:
         type: string
-        enum: [SimpleInterval]
-        default: SimpleInterval
+        enum: ["SimpleInterval"]
+        default: "SimpleInterval"
       start:
         type: ["integer", "null"]
         default: null
@@ -319,8 +319,8 @@ definitions:
     properties:
       type:
         type: string
-        enum: [NestedInterval]
-        default: NestedInterval
+        enum: ["NestedInterval"]
+        default: "NestedInterval"
       inner:
         $ref: '#/definitions/SimpleInterval'
       outer:
@@ -422,8 +422,8 @@ definitions:
     properties:
       type:
         type: string
-        enum: [CytobandInterval]
-        default: CytobandInterval
+        enum: ["CytobandInterval"]
+        default: "CytobandInterval"
       start:
         $ref: "#/definitions/Cytoband"
       end:
@@ -525,8 +525,8 @@ definitions:
     properties:
       type:
         type: string
-        enum: [SequenceState]
-        default: SequenceState
+        enum: ["SequenceState"]
+        default: "SequenceState"
       sequence:
         type: string
         nullable: false

--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -164,7 +164,7 @@ definitions:
     additionalProperties: false
     type: object
     description: >-
-      Absolute abundance of a systemic subject such as a Gene or
+      Absolute abundance of a systemic subject such as a gene or
       specific type of molecular variation.
     properties:
       _id:
@@ -177,9 +177,9 @@ definitions:
         oneOf:
           - $ref: "#/definitions/Allele"
           - $ref: "#/definitions/Haplotype"
-          - $ref: "#/definitions/Gene"
+          - $ref: "#/definitions/CURIE"
       amount:
-        $ref: "#/definitions/Range"
+        $ref: "#/definitions/IntegerRange"
     required:
       - type
       - subject
@@ -189,7 +189,7 @@ definitions:
     additionalProperties: false
     type: object
     description: >-
-      Relative abundance of a systemic subject such as a Gene or
+      Relative abundance of a systemic subject such as a gene or
       specific type of molecular variation.
     properties:
       _id:
@@ -201,7 +201,7 @@ definitions:
       subject:
         oneOf:
           - $ref: "#/definitions/MolecularVariation"
-          - $ref: "#/definitions/Gene"
+          - $ref: "#/definitions/CURIE"
       amount:
         type: string
         enum: ["gt", "ge", "eq", "le", "lt"]
@@ -217,7 +217,6 @@ definitions:
     oneOf:
       - $ref: "#/definitions/ChromosomeLocation"
       - $ref: "#/definitions/SequenceLocation"
-      - $ref: "#/definitions/TranscriptLocation"
     discriminator:
       propertyName: type
 
@@ -415,12 +414,10 @@ definitions:
     type: object
     additionalProperties: false
     properties:
-      _id:
-        $ref: "#/definitions/CURIE"
       type:
         type: string
-        enum: [Gene]
-        default: Gene
+        enum: ["Gene"]
+        default: "Gene"
       gene_id:
         $ref: "#/definitions/CURIE"
 
@@ -497,13 +494,17 @@ definitions:
     type: string
     format: "date-time"
 
-  Range:
+  IntegerRange:
     description: >-
       A (min,max) range of integer values. At least one of min or max
       must be specified.
     additionalProperties: false
     type: object
     properties:
+      type:
+        type: string
+        enum: ["IntegerRange"]
+        default: "IntegerRange"
       min:
         type: ["integer", "null"]
         default: null
@@ -511,9 +512,9 @@ definitions:
         type: ["integer", "null"]
         default: null
     example:
-      type: Range
-      start: 11
-      end: 22
+      type: "IntegerRange"
+      min: 5
+      max: 10
 
 
   # =============================================================================

--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -373,8 +373,8 @@ definitions:
         $ref: "#/definitions/SequenceLocation"
       transformation:
         type: string
-        enum: ["reverse", "complement", "reverse-complement"]
-        default: null
+        enum: ["none", "reverse", "complement", "reverse-complement"]
+        default: "none"
 
   RepeatedSequence:
     description: >-
@@ -389,14 +389,7 @@ definitions:
       sequence:
         $ref: "#/definitions/SequenceExpression"
       count:
-        type: object
-        additionalProperties: false
-        properties:
-          min:
-            type: integer
-            minimum: 0
-          max:
-            type: ["integer", "null"]
+        $ref: "#/definitions/IntegerRange"
     required:
       - type
       - count


### PR DESCRIPTION
See rendering in https://vrs.ga4gh.org/en/46-repeat-and-abundance/terms_and_model.html.
Changes in other files are insignificant.

Changes:

* Added documentation for LiteralSequence, DerivedSequence, RepeatedSequence, SequenceExpressions
* Added documentation for both Abundance classes
* Renamed Range to IntegerRange. (Seems that we might want a float range later.)
* Deprecated State and SequenceState
* Rearranged variation to use Molecular, Systemic, Other taxonomy
* Rearranged for top-down presentation (i.e., variation → location → sequence expressions → primitive, rather than the inverse order)

Note: I do *not* think this documentation is perfect. However, I do think that this PR substantially addresses the needs of this issue. We can then come back for more polishing.
