### PR TITLE
Keep issues alive

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,4 +21,4 @@ jobs:
           This pull request was marked stale due to inactivity.
         days-before-stale: 60
         days-before-close: 14
-        exempt-issue-labels: "Stayin' Alive"
+        exempt-issue-label: "Stayin' Alive"


### PR DESCRIPTION
Currently "stayin alive" labeled issues are labeled stale and removed. This PR fixes that.