### PR TITLE
Fixes #295: Revert schema changes that cause exceptions in pjs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,3 +25,5 @@ jobs:
       - name: Test with pytest
         run: |
           pytest
+        env:
+          PYTHONPATH: /home/runner/work/vrs/vrs/

--- a/schema/helpers.py
+++ b/schema/helpers.py
@@ -1,0 +1,11 @@
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def pjs_filter(yaml_dict):
+    for message_name, message_definition in yaml_dict['definitions'].items():
+        if 'anyOf' in message_definition:
+            _logger.warning(f'Removing anyOf attribute from {message_name} to avoid pjs error.')
+            del message_definition['anyOf']
+    return yaml_dict

--- a/schema/vrs.json
+++ b/schema/vrs.json
@@ -541,7 +541,7 @@
                "type": "integer"
             }
          },
-         "oneOf": [
+         "anyOf": [
             {
                "required": [
                   "type",

--- a/schema/vrs.json
+++ b/schema/vrs.json
@@ -459,16 +459,7 @@
                "default": "RepeatedSequenceExpression"
             },
             "seq_expr": {
-               "allOf": [
-                  {
-                     "$ref": "#/definitions/SequenceExpression"
-                  },
-                  {
-                     "not": {
-                        "$ref": "#/definitions/RepeatedSequenceExpression"
-                     }
-                  }
-               ]
+               "$ref": "#/definitions/SequenceExpression"
             },
             "count": {
                "$ref": "#/definitions/Range"
@@ -542,21 +533,7 @@
             "max": {
                "type": "integer"
             }
-         },
-         "anyOf": [
-            {
-               "required": [
-                  "type",
-                  "min"
-               ]
-            },
-            {
-               "required": [
-                  "type",
-                  "max"
-               ]
-            }
-         ]
+         }
       },
       "Sequence": {
          "additionalProperties": false,

--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -414,7 +414,7 @@ definitions:
         type: integer
       max:
         type: integer
-    oneOf:
+    anyOf:
       - required: [ "type", "min" ]
       - required: [ "type", "max" ]
 

--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -350,10 +350,7 @@ definitions:
         enum: ["RepeatedSequenceExpression"]
         default: "RepeatedSequenceExpression"
       seq_expr:
-        allOf:
-          - $ref: "#/definitions/SequenceExpression"
-          - not:
-              $ref: "#/definitions/RepeatedSequenceExpression"
+        $ref: "#/definitions/SequenceExpression"
       count:
         $ref: "#/definitions/Range"
     example:
@@ -415,10 +412,6 @@ definitions:
         type: integer
       max:
         type: integer
-    anyOf:
-      - required: [ "type", "min" ]
-      - required: [ "type", "max" ]
-
 
   # =============================================================================
   # BASIC TYPES (STRUCTURES)

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-import pytest
-
 root_dir = Path(__file__).parent.parent
 schema_dir = root_dir / "schema"
 vrs_yaml_path = schema_dir / "vrs.yaml"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -13,5 +13,6 @@ assert y == j, "parsed yaml and json do not match"
 
 
 # Can pjs handle this schema?
-ob = pjs.ObjectBuilder("schema/vrs.json")
-ob.build_classes()              # no exception => okay
+def test_pjs_smoke():
+    ob = pjs.ObjectBuilder("schema/vrs.json")
+    assert ob.build_classes()              # no exception => okay

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2,17 +2,20 @@ import json
 
 import python_jsonschema_objects as pjs
 import yaml
+from schema.helpers import pjs_filter
 
 from config import vrs_json_path, vrs_yaml_path
 
-
-# Are the yaml and json parseable and do they match?
+# Are the yaml and json parsable and do they match?
 y = yaml.load(open(vrs_yaml_path), Loader=yaml.SafeLoader)
 j = json.load(open(vrs_json_path))
-assert y == j, "parsed yaml and json do not match"
+
+
+def test_json_yaml_match():
+    assert y == j, "parsed yaml and json do not match"
 
 
 # Can pjs handle this schema?
 def test_pjs_smoke():
-    ob = pjs.ObjectBuilder("schema/vrs.json")
+    ob = pjs.ObjectBuilder(pjs_filter(y))
     assert ob.build_classes()              # no exception => okay


### PR DESCRIPTION
Two recent changes conflict with python-jsonschema-objects, an essential library used by vrs-python.

#### `NotImplementedError: anyOf is not supported as bare property`

I attempted several workarounds but eventually had to drop the conditional required. 

#### `RecursionError: maximum recursion depth exceeded in comparison`.

Again, no workarounds were found. Apparently, PJS can't support the recursion created by the negated constraint even though it can handle simpler recursion through a parent class.