### PR TITLE
258 update validation tests

### DIFF
--- a/notebooks/Examples and Validation Tests.ipynb
+++ b/notebooks/Examples and Validation Tests.ipynb
@@ -1,0 +1,1986 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Examples and Validation Tests\n",
+    "\n",
+    "This notebook is used to generate yaml schema examples, documentation examples, and validation tests (in [vrs/validation/](https://github.com/ga4gh/vrs/tree/main/validation)). The intention is to have a coherent set of tested examples. Many of the tests are intended to work up to alleles, haplotypes, and genotypes of ApoE. That is:\n",
+    "\n",
+    "```\n",
+    "                             rs7412 \n",
+    "                             NC_000019.9:g.45411941\n",
+    "                             NC_000019.10:g.44908822\n",
+    "                             NM_000041.3:c.526\n",
+    "rs429358                        C          T\n",
+    "NC_000019.9:g.45412079   C   APOE-ε4    APOE-ε1\n",
+    "NC_000019.10:g.44908684  T   APOE-ε3    APOE-ε2\n",
+    "NM_000041.3:c.388\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Removing allOf attribute from CopyNumber to avoid pjs error.\n",
+      "Removing allOf attribute from SequenceInterval to avoid pjs error.\n",
+      "Removing allOf attribute from RepeatedSequenceExpression to avoid pjs error.\n",
+      "/home/reece/projects/ga4gh/vrs-python/venv/3.9/lib/python3.9/site-packages/python_jsonschema_objects/__init__.py:50: UserWarning: Schema version http://json-schema.org/draft-07/schema not recognized. Some keywords and features may not be supported.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'0.7.0rc4.dev2+g62f9c0e.d20210620'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import string\n",
+    "import yaml\n",
+    "\n",
+    "from IPython.display import display, Markdown\n",
+    "\n",
+    "from ga4gh.core import ga4gh_digest, ga4gh_identify, ga4gh_serialize, is_identifiable, sha512t24u\n",
+    "from ga4gh.vrs import __version__, models, normalize\n",
+    "__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def filter_dict(d) -> dict:\n",
+    "    \"\"\"remove keys starting with underscore\"\"\"\n",
+    "    try:\n",
+    "        return {k: filter_dict(d[k])\n",
+    "                for k in d\n",
+    "                if not k.startswith(\"_\")}\n",
+    "    except:\n",
+    "        return d\n",
+    "def dump_json(o) -> str:\n",
+    "    \"\"\"return VRS object as pretty formated json (string)\"\"\"\n",
+    "    return json.dumps(filter_dict(o.as_dict()), indent=2, sort_keys=True)\n",
+    "def dump_tests(o, fns=None) -> str:\n",
+    "    \"\"\"return VRS object with and function results as yaml test definition (string)\"\"\"\n",
+    "    def as_str(s) -> str:\n",
+    "        return s if isinstance(s, str) else s.decode()\n",
+    "    if fns is None:\n",
+    "        fns = [ga4gh_serialize]\n",
+    "        if is_identifiable(o):\n",
+    "            fns += [ga4gh_digest, ga4gh_identify]\n",
+    "    r = {\n",
+    "        \"in\": o.as_dict(),\n",
+    "        \"out\": {f.__name__: as_str(f(o)) for f in fns}\n",
+    "    }\n",
+    "    return yaml.dump(filter_dict({o.type._value: {\"-\": r}})).replace(\"'-':\",\"-\")\n",
+    "\n",
+    "all_yaml = \"\"\n",
+    "def output(o) -> None:\n",
+    "    \"\"\"dump as json and yaml\"\"\"\n",
+    "    global all_yaml\n",
+    "    test_yaml = dump_tests(o)\n",
+    "    all_yaml += test_yaml\n",
+    "    md = [\n",
+    "        \"**example object**\",\n",
+    "        \"```\",\n",
+    "        dump_json(o),\n",
+    "        \"```\",\n",
+    "        \"\",\n",
+    "        \"**validation test**\",\n",
+    "        \"```\",\n",
+    "        test_yaml,\n",
+    "        \"```\",\n",
+    "    ]\n",
+    "    display(Markdown(\"\\n\".join(md)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These are the names of all models for which we want examples\n",
+    "examples = set(n for n in models if n[0] in string.ascii_uppercase and \"-\" not in n)\n",
+    "#for e in sorted(examples): print(f\"-[ ] {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "----\n",
+    "# External Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ga4gh.vrs.dataproxy import SeqRepoRESTDataProxy\n",
+    "seqrepo_rest_service_url = \"http://localhost:5000/seqrepo\"\n",
+    "dp = SeqRepoRESTDataProxy(base_url=seqrepo_rest_service_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_sequence(identifier, start=None, end=None):\n",
+    "    \"\"\"returns sequence for given identifier, optionally limited to interbase <start, end> interval\"\"\"\n",
+    "    return dp.get_sequence(identifier, start, end)\n",
+    "def get_sequence_length(identifier):\n",
+    "    \"\"\"return length of given sequence identifier\"\"\"\n",
+    "    return dp.get_metadata(identifier)[\"length\"]\n",
+    "def translate_sequence_identifier(identifier, namespace):\n",
+    "    \"\"\"return for given identifier, return *list* of equivalent identifiers in given namespace\"\"\"\n",
+    "    return dp.translate_sequence_identifier(identifier, namespace)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "58617616"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_sequence_length(\"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'CCGCGATGCCGATGACCTGCAGAAGCGCCTGGCAGTGTACCAGGCCGGGGC'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "start, end = 44908821-25, 44908822+25\n",
+    "get_sequence(\"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\", start, end)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['ga4gh:GS.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl']"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "translate_sequence_identifier(\"GRCh38:19\", \"ga4gh\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['GRCh38:19', 'GRCh38:chr19']"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "translate_sequence_identifier(\"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\", \"GRCh38\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "----\n",
+    "# Example objects"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Primitives Classes\n",
+    "Primitive classes do not have a \"type\" attribute. They make the schema easier to read/understand, and they provide some value validation to promote correctness."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ncbigene:384'"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "curie = models.CURIE(\"ncbigene:384\")\n",
+    "curie.for_json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### HumanCytoband"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'q13.32'"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "human_cytoband = models.HumanCytoband(\"q13.32\")\n",
+    "human_cytoband.for_json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sequence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ACGT'"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sequence = models.Sequence(\"ACGT\")\n",
+    "sequence.for_json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Base Types\n",
+    "These classes have a \"type\" attribute. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Number"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"type\": \"Number\",\n",
+       "  \"value\": 55\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "Number:\n",
+       "  -\n",
+       "    in:\n",
+       "      type: Number\n",
+       "      value: 55\n",
+       "    out:\n",
+       "      ga4gh_serialize: '{\"type\":\"Number\",\"value\":55}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "number = models.Number(value=55)\n",
+    "output(number)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Gene"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"gene_id\": \"ncbigene:384\",\n",
+       "  \"type\": \"Gene\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "Gene:\n",
+       "  -\n",
+       "    in:\n",
+       "      gene_id: ncbigene:384\n",
+       "      type: Gene\n",
+       "    out:\n",
+       "      ga4gh_serialize: '{\"gene_id\":\"ncbigene:384\",\"type\":\"Gene\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "gene = models.Gene(gene_id=\"ncbigene:384\")\n",
+    "output(gene)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Locations and Intervals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SimpleInterval (DEPRECATED)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"end\": 44908822,\n",
+       "  \"start\": 44908821,\n",
+       "  \"type\": \"SimpleInterval\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "SimpleInterval:\n",
+       "  -\n",
+       "    in:\n",
+       "      end: 44908822\n",
+       "      start: 44908821\n",
+       "      type: SimpleInterval\n",
+       "    out:\n",
+       "      ga4gh_serialize: '{\"end\":44908822,\"start\":44908821,\"type\":\"SimpleInterval\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "simple_interval = models.SimpleInterval(start=44908821, end=44908822)\n",
+    "output(simple_interval)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DefiniteRange"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"max\": 33,\n",
+       "  \"min\": 22,\n",
+       "  \"type\": \"DefiniteRange\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "DefiniteRange:\n",
+       "  -\n",
+       "    in:\n",
+       "      max: 33\n",
+       "      min: 22\n",
+       "      type: DefiniteRange\n",
+       "    out:\n",
+       "      ga4gh_serialize: '{\"max\":33,\"min\":22,\"type\":\"DefiniteRange\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def_range = models.DefiniteRange(\n",
+    "  min=22,\n",
+    "  max=33)\n",
+    "output(def_range)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### IndefiniteRange"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"comparator\": \">=\",\n",
+       "  \"type\": \"IndefiniteRange\",\n",
+       "  \"value\": 22\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "IndefiniteRange:\n",
+       "  -\n",
+       "    in:\n",
+       "      comparator: '>='\n",
+       "      type: IndefiniteRange\n",
+       "      value: 22\n",
+       "    out:\n",
+       "      ga4gh_serialize: '{\"comparator\":\">=\",\"type\":\"IndefiniteRange\",\"value\":22}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def_range = models.IndefiniteRange(\n",
+    "  value=22,\n",
+    "  comparator=\">=\")\n",
+    "output(def_range)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SequenceInterval"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"end\": {\n",
+       "    \"type\": \"Number\",\n",
+       "    \"value\": 44908822\n",
+       "  },\n",
+       "  \"start\": {\n",
+       "    \"type\": \"Number\",\n",
+       "    \"value\": 44908821\n",
+       "  },\n",
+       "  \"type\": \"SequenceInterval\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "SequenceInterval:\n",
+       "  -\n",
+       "    in:\n",
+       "      end:\n",
+       "        type: Number\n",
+       "        value: 44908822\n",
+       "      start:\n",
+       "        type: Number\n",
+       "        value: 44908821\n",
+       "      type: SequenceInterval\n",
+       "    out:\n",
+       "      ga4gh_serialize: '{\"end\":{\"type\":\"Number\",\"value\":44908822},\"start\":{\"type\":\"Number\",\"value\":44908821},\"type\":\"SequenceInterval\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "simple_sequence_interval = models.SequenceInterval(start=models.Number(value=44908821), end=models.Number(value=44908822))\n",
+    "output(simple_sequence_interval)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"end\": {\n",
+       "    \"comparator\": \">=\",\n",
+       "    \"type\": \"IndefiniteRange\",\n",
+       "    \"value\": 44908822\n",
+       "  },\n",
+       "  \"start\": {\n",
+       "    \"max\": 44908821,\n",
+       "    \"min\": 44908721,\n",
+       "    \"type\": \"DefiniteRange\"\n",
+       "  },\n",
+       "  \"type\": \"SequenceInterval\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "SequenceInterval:\n",
+       "  -\n",
+       "    in:\n",
+       "      end:\n",
+       "        comparator: '>='\n",
+       "        type: IndefiniteRange\n",
+       "        value: 44908822\n",
+       "      start:\n",
+       "        max: 44908821\n",
+       "        min: 44908721\n",
+       "        type: DefiniteRange\n",
+       "      type: SequenceInterval\n",
+       "    out:\n",
+       "      ga4gh_serialize: '{\"end\":{\"comparator\":\">=\",\"type\":\"IndefiniteRange\",\"value\":44908822},\"start\":{\"max\":44908821,\"min\":44908721,\"type\":\"DefiniteRange\"},\"type\":\"SequenceInterval\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "complex_sequence_interval = models.SequenceInterval(\n",
+    "    start=models.DefiniteRange(min=44908821-100, max=44908821),\n",
+    "    end=models.IndefiniteRange(value=44908822, comparator=\">=\"))\n",
+    "output(complex_sequence_interval)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SequenceLocation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"interval\": {\n",
+       "    \"end\": {\n",
+       "      \"type\": \"Number\",\n",
+       "      \"value\": 44908822\n",
+       "    },\n",
+       "    \"start\": {\n",
+       "      \"type\": \"Number\",\n",
+       "      \"value\": 44908821\n",
+       "    },\n",
+       "    \"type\": \"SequenceInterval\"\n",
+       "  },\n",
+       "  \"sequence_id\": \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n",
+       "  \"type\": \"SequenceLocation\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "SequenceLocation:\n",
+       "  -\n",
+       "    in:\n",
+       "      interval:\n",
+       "        end:\n",
+       "          type: Number\n",
+       "          value: 44908822\n",
+       "        start:\n",
+       "          type: Number\n",
+       "          value: 44908821\n",
+       "        type: SequenceInterval\n",
+       "      sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\n",
+       "      type: SequenceLocation\n",
+       "    out:\n",
+       "      ga4gh_digest: QrRSuBj-VScAGV_gEdxNgsnh41jYH1Kg\n",
+       "      ga4gh_identify: ga4gh:VSL.QrRSuBj-VScAGV_gEdxNgsnh41jYH1Kg\n",
+       "      ga4gh_serialize: '{\"interval\":{\"end\":{\"type\":\"Number\",\"value\":44908822},\"start\":{\"type\":\"Number\",\"value\":44908821},\"type\":\"SequenceInterval\"},\"sequence_id\":\"IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\"type\":\"SequenceLocation\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "simple_sequence_location = models.SequenceLocation(\n",
+    "    sequence_id=\"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n",
+    "    interval=simple_sequence_interval)\n",
+    "output(simple_sequence_location)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"interval\": {\n",
+       "    \"end\": {\n",
+       "      \"comparator\": \">=\",\n",
+       "      \"type\": \"IndefiniteRange\",\n",
+       "      \"value\": 44908822\n",
+       "    },\n",
+       "    \"start\": {\n",
+       "      \"max\": 44908821,\n",
+       "      \"min\": 44908721,\n",
+       "      \"type\": \"DefiniteRange\"\n",
+       "    },\n",
+       "    \"type\": \"SequenceInterval\"\n",
+       "  },\n",
+       "  \"sequence_id\": \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n",
+       "  \"type\": \"SequenceLocation\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "SequenceLocation:\n",
+       "  -\n",
+       "    in:\n",
+       "      interval:\n",
+       "        end:\n",
+       "          comparator: '>='\n",
+       "          type: IndefiniteRange\n",
+       "          value: 44908822\n",
+       "        start:\n",
+       "          max: 44908821\n",
+       "          min: 44908721\n",
+       "          type: DefiniteRange\n",
+       "        type: SequenceInterval\n",
+       "      sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\n",
+       "      type: SequenceLocation\n",
+       "    out:\n",
+       "      ga4gh_digest: 2ZIY16gPTLbVISuREaRmb0jXGj-_IdRv\n",
+       "      ga4gh_identify: ga4gh:VSL.2ZIY16gPTLbVISuREaRmb0jXGj-_IdRv\n",
+       "      ga4gh_serialize: '{\"interval\":{\"end\":{\"comparator\":\">=\",\"type\":\"IndefiniteRange\",\"value\":44908822},\"start\":{\"max\":44908821,\"min\":44908721,\"type\":\"DefiniteRange\"},\"type\":\"SequenceInterval\"},\"sequence_id\":\"IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\"type\":\"SequenceLocation\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "complex_sequence_location = models.SequenceLocation(\n",
+    "    sequence_id=\"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n",
+    "    interval=complex_sequence_interval)\n",
+    "output(complex_sequence_location)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### CytobandInterval"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"end\": \"q13.32\",\n",
+       "  \"start\": \"q13.32\",\n",
+       "  \"type\": \"CytobandInterval\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "CytobandInterval:\n",
+       "  -\n",
+       "    in:\n",
+       "      end: q13.32\n",
+       "      start: q13.32\n",
+       "      type: CytobandInterval\n",
+       "    out:\n",
+       "      ga4gh_serialize: '{\"end\":\"q13.32\",\"start\":\"q13.32\",\"type\":\"CytobandInterval\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cytoband_interval = models.CytobandInterval(\n",
+    "    start=models.HumanCytoband(\"q13.32\"),\n",
+    "    end=models.HumanCytoband(\"q13.32\"))\n",
+    "output(cytoband_interval)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### ChromosomeLocation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"chr\": \"19\",\n",
+       "  \"interval\": {\n",
+       "    \"end\": \"q13.32\",\n",
+       "    \"start\": \"q13.32\",\n",
+       "    \"type\": \"CytobandInterval\"\n",
+       "  },\n",
+       "  \"species_id\": \"taxonomy:9606\",\n",
+       "  \"type\": \"ChromosomeLocation\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "ChromosomeLocation:\n",
+       "  -\n",
+       "    in:\n",
+       "      chr: '19'\n",
+       "      interval:\n",
+       "        end: q13.32\n",
+       "        start: q13.32\n",
+       "        type: CytobandInterval\n",
+       "      species_id: taxonomy:9606\n",
+       "      type: ChromosomeLocation\n",
+       "    out:\n",
+       "      ga4gh_digest: HLH0tBIjV4Vxr_814b41hBsICouJkSN1\n",
+       "      ga4gh_identify: ga4gh:VCL.HLH0tBIjV4Vxr_814b41hBsICouJkSN1\n",
+       "      ga4gh_serialize: '{\"chr\":\"19\",\"interval\":{\"end\":\"q13.32\",\"start\":\"q13.32\",\"type\":\"CytobandInterval\"},\"species_id\":\"taxonomy:9606\",\"type\":\"ChromosomeLocation\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "chromosome_location = models.ChromosomeLocation(\n",
+    "    species_id=\"taxonomy:9606\",\n",
+    "    chr=\"19\",\n",
+    "    interval=cytoband_interval\n",
+    ")\n",
+    "output(chromosome_location)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DerivedSequenceExpression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"location\": {\n",
+       "    \"interval\": {\n",
+       "      \"end\": {\n",
+       "        \"type\": \"Number\",\n",
+       "        \"value\": 44908822\n",
+       "      },\n",
+       "      \"start\": {\n",
+       "        \"type\": \"Number\",\n",
+       "        \"value\": 44908821\n",
+       "      },\n",
+       "      \"type\": \"SequenceInterval\"\n",
+       "    },\n",
+       "    \"sequence_id\": \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n",
+       "    \"type\": \"SequenceLocation\"\n",
+       "  },\n",
+       "  \"reverse_complement\": false,\n",
+       "  \"type\": \"DerivedSequenceExpression\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "DerivedSequenceExpression:\n",
+       "  -\n",
+       "    in:\n",
+       "      location:\n",
+       "        interval:\n",
+       "          end:\n",
+       "            type: Number\n",
+       "            value: 44908822\n",
+       "          start:\n",
+       "            type: Number\n",
+       "            value: 44908821\n",
+       "          type: SequenceInterval\n",
+       "        sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\n",
+       "        type: SequenceLocation\n",
+       "      reverse_complement: false\n",
+       "      type: DerivedSequenceExpression\n",
+       "    out:\n",
+       "      ga4gh_serialize: '{\"location\":\"QrRSuBj-VScAGV_gEdxNgsnh41jYH1Kg\",\"reverse_complement\":false,\"type\":\"DerivedSequenceExpression\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "dse = models.DerivedSequenceExpression(\n",
+    "    location = simple_sequence_location,\n",
+    "    reverse_complement = False\n",
+    ")\n",
+    "output(dse)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### LiteralSequenceExpression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"sequence\": \"ACGT\",\n",
+       "  \"type\": \"LiteralSequenceExpression\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "LiteralSequenceExpression:\n",
+       "  -\n",
+       "    in:\n",
+       "      sequence: ACGT\n",
+       "      type: LiteralSequenceExpression\n",
+       "    out:\n",
+       "      ga4gh_serialize: '{\"sequence\":\"ACGT\",\"type\":\"LiteralSequenceExpression\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "lse = models.LiteralSequenceExpression(\n",
+    "    sequence=\"ACGT\"\n",
+    ")\n",
+    "output(lse)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### RepeatedSequenceExpression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"count\": {\n",
+       "    \"comparator\": \">=\",\n",
+       "    \"type\": \"IndefiniteRange\",\n",
+       "    \"value\": 6\n",
+       "  },\n",
+       "  \"seq_expr\": {\n",
+       "    \"location\": {\n",
+       "      \"interval\": {\n",
+       "        \"end\": {\n",
+       "          \"type\": \"Number\",\n",
+       "          \"value\": 44908822\n",
+       "        },\n",
+       "        \"start\": {\n",
+       "          \"type\": \"Number\",\n",
+       "          \"value\": 44908821\n",
+       "        },\n",
+       "        \"type\": \"SequenceInterval\"\n",
+       "      },\n",
+       "      \"sequence_id\": \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n",
+       "      \"type\": \"SequenceLocation\"\n",
+       "    },\n",
+       "    \"reverse_complement\": false,\n",
+       "    \"type\": \"DerivedSequenceExpression\"\n",
+       "  },\n",
+       "  \"type\": \"RepeatedSequenceExpression\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "RepeatedSequenceExpression:\n",
+       "  -\n",
+       "    in:\n",
+       "      count:\n",
+       "        comparator: '>='\n",
+       "        type: IndefiniteRange\n",
+       "        value: 6\n",
+       "      seq_expr:\n",
+       "        location:\n",
+       "          interval:\n",
+       "            end:\n",
+       "              type: Number\n",
+       "              value: 44908822\n",
+       "            start:\n",
+       "              type: Number\n",
+       "              value: 44908821\n",
+       "            type: SequenceInterval\n",
+       "          sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\n",
+       "          type: SequenceLocation\n",
+       "        reverse_complement: false\n",
+       "        type: DerivedSequenceExpression\n",
+       "      type: RepeatedSequenceExpression\n",
+       "    out:\n",
+       "      ga4gh_serialize: '{\"count\":{\"comparator\":\">=\",\"type\":\"IndefiniteRange\",\"value\":6},\"seq_expr\":{\"location\":\"QrRSuBj-VScAGV_gEdxNgsnh41jYH1Kg\",\"reverse_complement\":false,\"type\":\"DerivedSequenceExpression\"},\"type\":\"RepeatedSequenceExpression\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "rse = models.RepeatedSequenceExpression(\n",
+    "    seq_expr = dse,\n",
+    "    count = models.IndefiniteRange(value=6, comparator=\">=\")\n",
+    ")\n",
+    "output(rse)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Molecular Variation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Allele"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"location\": {\n",
+       "    \"interval\": {\n",
+       "      \"end\": {\n",
+       "        \"type\": \"Number\",\n",
+       "        \"value\": 44908822\n",
+       "      },\n",
+       "      \"start\": {\n",
+       "        \"type\": \"Number\",\n",
+       "        \"value\": 44908821\n",
+       "      },\n",
+       "      \"type\": \"SequenceInterval\"\n",
+       "    },\n",
+       "    \"sequence_id\": \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n",
+       "    \"type\": \"SequenceLocation\"\n",
+       "  },\n",
+       "  \"state\": {\n",
+       "    \"sequence\": \"T\",\n",
+       "    \"type\": \"SequenceState\"\n",
+       "  },\n",
+       "  \"type\": \"Allele\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "Allele:\n",
+       "  -\n",
+       "    in:\n",
+       "      location:\n",
+       "        interval:\n",
+       "          end:\n",
+       "            type: Number\n",
+       "            value: 44908822\n",
+       "          start:\n",
+       "            type: Number\n",
+       "            value: 44908821\n",
+       "          type: SequenceInterval\n",
+       "        sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\n",
+       "        type: SequenceLocation\n",
+       "      state:\n",
+       "        sequence: T\n",
+       "        type: SequenceState\n",
+       "      type: Allele\n",
+       "    out:\n",
+       "      ga4gh_digest: KnG6BLTexv7o-j9LnYsgPxZkRUu1IRnp\n",
+       "      ga4gh_identify: ga4gh:VA.KnG6BLTexv7o-j9LnYsgPxZkRUu1IRnp\n",
+       "      ga4gh_serialize: '{\"location\":\"QrRSuBj-VScAGV_gEdxNgsnh41jYH1Kg\",\"state\":{\"sequence\":\"T\",\"type\":\"SequenceState\"},\"type\":\"Allele\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Allele with deprecated SequenceState\n",
+    "allele = models.Allele(location=simple_sequence_location,\n",
+    "                       state=models.SequenceState(sequence=\"T\"))\n",
+    "output(allele)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"location\": {\n",
+       "    \"interval\": {\n",
+       "      \"end\": {\n",
+       "        \"type\": \"Number\",\n",
+       "        \"value\": 44908822\n",
+       "      },\n",
+       "      \"start\": {\n",
+       "        \"type\": \"Number\",\n",
+       "        \"value\": 44908821\n",
+       "      },\n",
+       "      \"type\": \"SequenceInterval\"\n",
+       "    },\n",
+       "    \"sequence_id\": \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n",
+       "    \"type\": \"SequenceLocation\"\n",
+       "  },\n",
+       "  \"state\": {\n",
+       "    \"sequence\": \"T\",\n",
+       "    \"type\": \"LiteralSequenceExpression\"\n",
+       "  },\n",
+       "  \"type\": \"Allele\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "Allele:\n",
+       "  -\n",
+       "    in:\n",
+       "      location:\n",
+       "        interval:\n",
+       "          end:\n",
+       "            type: Number\n",
+       "            value: 44908822\n",
+       "          start:\n",
+       "            type: Number\n",
+       "            value: 44908821\n",
+       "          type: SequenceInterval\n",
+       "        sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\n",
+       "        type: SequenceLocation\n",
+       "      state:\n",
+       "        sequence: T\n",
+       "        type: LiteralSequenceExpression\n",
+       "      type: Allele\n",
+       "    out:\n",
+       "      ga4gh_digest: CxiA_hvYbkD8Vqwjhx5AYuyul4mtlkpD\n",
+       "      ga4gh_identify: ga4gh:VA.CxiA_hvYbkD8Vqwjhx5AYuyul4mtlkpD\n",
+       "      ga4gh_serialize: '{\"location\":\"QrRSuBj-VScAGV_gEdxNgsnh41jYH1Kg\",\"state\":{\"sequence\":\"T\",\"type\":\"LiteralSequenceExpression\"},\"type\":\"Allele\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Allele with LiteralSequenceExpression\n",
+    "allele = models.Allele(location=simple_sequence_location,\n",
+    "                       state=models.LiteralSequenceExpression(sequence=\"T\"))\n",
+    "output(allele)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Haplotype"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"members\": [\n",
+       "    {\n",
+       "      \"location\": {\n",
+       "        \"interval\": {\n",
+       "          \"end\": {\n",
+       "            \"type\": \"Number\",\n",
+       "            \"value\": 44908822\n",
+       "          },\n",
+       "          \"start\": {\n",
+       "            \"type\": \"Number\",\n",
+       "            \"value\": 44908821\n",
+       "          },\n",
+       "          \"type\": \"SequenceInterval\"\n",
+       "        },\n",
+       "        \"sequence_id\": \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n",
+       "        \"type\": \"SequenceLocation\"\n",
+       "      },\n",
+       "      \"state\": {\n",
+       "        \"sequence\": \"C\",\n",
+       "        \"type\": \"LiteralSequenceExpression\"\n",
+       "      },\n",
+       "      \"type\": \"Allele\"\n",
+       "    },\n",
+       "    {\n",
+       "      \"location\": {\n",
+       "        \"interval\": {\n",
+       "          \"end\": {\n",
+       "            \"type\": \"Number\",\n",
+       "            \"value\": 44908684\n",
+       "          },\n",
+       "          \"start\": {\n",
+       "            \"type\": \"Number\",\n",
+       "            \"value\": 44908683\n",
+       "          },\n",
+       "          \"type\": \"SequenceInterval\"\n",
+       "        },\n",
+       "        \"sequence_id\": \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n",
+       "        \"type\": \"SequenceLocation\"\n",
+       "      },\n",
+       "      \"state\": {\n",
+       "        \"sequence\": \"C\",\n",
+       "        \"type\": \"LiteralSequenceExpression\"\n",
+       "      },\n",
+       "      \"type\": \"Allele\"\n",
+       "    }\n",
+       "  ],\n",
+       "  \"type\": \"Haplotype\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "Haplotype:\n",
+       "  -\n",
+       "    in:\n",
+       "      members:\n",
+       "      - location:\n",
+       "          interval:\n",
+       "            end:\n",
+       "              type: Number\n",
+       "              value: 44908822\n",
+       "            start:\n",
+       "              type: Number\n",
+       "              value: 44908821\n",
+       "            type: SequenceInterval\n",
+       "          sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\n",
+       "          type: SequenceLocation\n",
+       "        state:\n",
+       "          sequence: C\n",
+       "          type: LiteralSequenceExpression\n",
+       "        type: Allele\n",
+       "      - location:\n",
+       "          interval:\n",
+       "            end:\n",
+       "              type: Number\n",
+       "              value: 44908684\n",
+       "            start:\n",
+       "              type: Number\n",
+       "              value: 44908683\n",
+       "            type: SequenceInterval\n",
+       "          sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\n",
+       "          type: SequenceLocation\n",
+       "        state:\n",
+       "          sequence: C\n",
+       "          type: LiteralSequenceExpression\n",
+       "        type: Allele\n",
+       "      type: Haplotype\n",
+       "    out:\n",
+       "      ga4gh_digest: i8owCOBHIlRCPtcw_WzRFNTunwJRy99-\n",
+       "      ga4gh_identify: ga4gh:VH.i8owCOBHIlRCPtcw_WzRFNTunwJRy99-\n",
+       "      ga4gh_serialize: '{\"members\":[\"-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x\",\"Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1\"],\"type\":\"Haplotype\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "rs7412_38 = models.SequenceLocation(\n",
+    "    sequence_id=\"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n",
+    "    interval=models.SequenceInterval(\n",
+    "        start=models.Number(value=44908821),\n",
+    "        end=models.Number(value=44908822)),\n",
+    ")\n",
+    "rs429358_38 = models.SequenceLocation(\n",
+    "    sequence_id=\"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n",
+    "    interval=models.SequenceInterval(\n",
+    "        start=models.Number(value=44908683),\n",
+    "        end=models.Number(value=44908684)),\n",
+    ")\n",
+    "rs7412_38C = models.Allele(\n",
+    "    location=rs7412_38,\n",
+    "    state=models.LiteralSequenceExpression(sequence=\"C\")\n",
+    ")\n",
+    "rs429358_38C = models.Allele(\n",
+    "    location=rs429358_38,\n",
+    "    state=models.LiteralSequenceExpression(sequence=\"C\")\n",
+    ")\n",
+    "haplotype = models.Haplotype(\n",
+    "    members=[rs7412_38C, rs429358_38C]\n",
+    ")\n",
+    "output(haplotype)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Systemic Variation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### CopyNumber"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"copies\": {\n",
+       "    \"comparator\": \">=\",\n",
+       "    \"type\": \"IndefiniteRange\",\n",
+       "    \"value\": 3\n",
+       "  },\n",
+       "  \"subject\": {\n",
+       "    \"gene_id\": \"ncbigene:384\",\n",
+       "    \"type\": \"Gene\"\n",
+       "  },\n",
+       "  \"type\": \"CopyNumber\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "CopyNumber:\n",
+       "  -\n",
+       "    in:\n",
+       "      copies:\n",
+       "        comparator: '>='\n",
+       "        type: IndefiniteRange\n",
+       "        value: 3\n",
+       "      subject:\n",
+       "        gene_id: ncbigene:384\n",
+       "        type: Gene\n",
+       "      type: CopyNumber\n",
+       "    out:\n",
+       "      ga4gh_digest: xksSWn--_z28Qaj-Udlhot4OKqYGkywy\n",
+       "      ga4gh_identify: ga4gh:VCN.xksSWn--_z28Qaj-Udlhot4OKqYGkywy\n",
+       "      ga4gh_serialize: '{\"copies\":{\"comparator\":\">=\",\"type\":\"IndefiniteRange\",\"value\":3},\"subject\":{\"gene_id\":\"ncbigene:384\",\"type\":\"Gene\"},\"type\":\"CopyNumber\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "copy_number = models.CopyNumber(\n",
+    "    subject=models.Gene(gene_id=\"ncbigene:384\"),\n",
+    "    copies=models.IndefiniteRange(value=3, comparator=\">=\")\n",
+    ")\n",
+    "output(copy_number)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Utility Variation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"definition\": \"APOE loss\",\n",
+       "  \"type\": \"Text\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "Text:\n",
+       "  -\n",
+       "    in:\n",
+       "      definition: APOE loss\n",
+       "      type: Text\n",
+       "    out:\n",
+       "      ga4gh_digest: 7hhlAaPeqj-sd67nSWXl7WC1yJ-g15tp\n",
+       "      ga4gh_identify: ga4gh:VT.7hhlAaPeqj-sd67nSWXl7WC1yJ-g15tp\n",
+       "      ga4gh_serialize: '{\"definition\":\"APOE loss\",\"type\":\"Text\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "text_variation = models.Text(definition=\"APOE loss\")\n",
+    "output(text_variation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### VariationSet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"members\": [\n",
+       "    {\n",
+       "      \"location\": {\n",
+       "        \"interval\": {\n",
+       "          \"end\": {\n",
+       "            \"type\": \"Number\",\n",
+       "            \"value\": 44908822\n",
+       "          },\n",
+       "          \"start\": {\n",
+       "            \"type\": \"Number\",\n",
+       "            \"value\": 44908821\n",
+       "          },\n",
+       "          \"type\": \"SequenceInterval\"\n",
+       "        },\n",
+       "        \"sequence_id\": \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n",
+       "        \"type\": \"SequenceLocation\"\n",
+       "      },\n",
+       "      \"state\": {\n",
+       "        \"sequence\": \"C\",\n",
+       "        \"type\": \"LiteralSequenceExpression\"\n",
+       "      },\n",
+       "      \"type\": \"Allele\"\n",
+       "    },\n",
+       "    {\n",
+       "      \"location\": {\n",
+       "        \"interval\": {\n",
+       "          \"end\": {\n",
+       "            \"type\": \"Number\",\n",
+       "            \"value\": 44908684\n",
+       "          },\n",
+       "          \"start\": {\n",
+       "            \"type\": \"Number\",\n",
+       "            \"value\": 44908683\n",
+       "          },\n",
+       "          \"type\": \"SequenceInterval\"\n",
+       "        },\n",
+       "        \"sequence_id\": \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n",
+       "        \"type\": \"SequenceLocation\"\n",
+       "      },\n",
+       "      \"state\": {\n",
+       "        \"sequence\": \"C\",\n",
+       "        \"type\": \"LiteralSequenceExpression\"\n",
+       "      },\n",
+       "      \"type\": \"Allele\"\n",
+       "    }\n",
+       "  ],\n",
+       "  \"type\": \"VariationSet\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "VariationSet:\n",
+       "  -\n",
+       "    in:\n",
+       "      members:\n",
+       "      - location:\n",
+       "          interval:\n",
+       "            end:\n",
+       "              type: Number\n",
+       "              value: 44908822\n",
+       "            start:\n",
+       "              type: Number\n",
+       "              value: 44908821\n",
+       "            type: SequenceInterval\n",
+       "          sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\n",
+       "          type: SequenceLocation\n",
+       "        state:\n",
+       "          sequence: C\n",
+       "          type: LiteralSequenceExpression\n",
+       "        type: Allele\n",
+       "      - location:\n",
+       "          interval:\n",
+       "            end:\n",
+       "              type: Number\n",
+       "              value: 44908684\n",
+       "            start:\n",
+       "              type: Number\n",
+       "              value: 44908683\n",
+       "            type: SequenceInterval\n",
+       "          sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\n",
+       "          type: SequenceLocation\n",
+       "        state:\n",
+       "          sequence: C\n",
+       "          type: LiteralSequenceExpression\n",
+       "        type: Allele\n",
+       "      type: VariationSet\n",
+       "    out:\n",
+       "      ga4gh_digest: QLQXSNSIFlqNYWmQbw-YkfmexPi4NeDE\n",
+       "      ga4gh_identify: ga4gh:VS.QLQXSNSIFlqNYWmQbw-YkfmexPi4NeDE\n",
+       "      ga4gh_serialize: '{\"members\":[\"-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x\",\"Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1\"],\"type\":\"VariationSet\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "variation_set = models.VariationSet(members=[rs7412_38C, rs429358_38C])\n",
+    "output(variation_set)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "----\n",
+    "# Functions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Truncated Digest (sha512t24u)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXc'"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sha512t24u(b\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'aKF498dAxcJAqme6QYQ7EZ07-fiw8Kw2'"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sha512t24u(b\"ACGT\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Digest Serialization (`ga4gh_serialize`)\n",
+    "\n",
+    "The ga4gh digest serialization form is like json, but it the specification ensures that all implementations will produce the same binary payload."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'{\"location\":\"u5fspwVbQ79QkX6GHLF8tXPCAXFJqRPx\",\"state\":{\"sequence\":\"T\",\"type\":\"SequenceState\"},\"type\":\"Allele\"}'"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "allele = models.Allele(location=models.SequenceLocation(\n",
+    "    sequence_id=\"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n",
+    "    interval=simple_interval),\n",
+    "    state=models.SequenceState(sequence=\"T\"))\n",
+    "ga4gh_serialize(allele)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Object Digest (`ga4gh_digest`)\n",
+    "VR computed identifiers are constructed from digests on serialized objects by prefixing a VR digest with a type-specific code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH_'"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# applying ga4gh_digest to the serialized allele returns a base64url-encoded digest\n",
+    "ga4gh_digest(allele)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH_'"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Which is equivalent to\n",
+    "sha512t24u(ga4gh_serialize(allele))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Object Computed Identifier (`ga4gh_identify`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ga4gh:VA.EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH_'"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ga4gh_identify(allele)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Write test yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9601"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "open(\"/tmp/validation.yaml\", \"w\").write(all_yaml)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/Examples and Validation Tests.ipynb
+++ b/notebooks/Examples and Validation Tests.ipynb
@@ -39,7 +39,7 @@
     {
      "data": {
       "text/plain": [
-       "'0.7.0rc4.dev2+g62f9c0e.d20210620'"
+       "'0.7.0rc4.dev3+g3abb629.d20210620'"
       ]
      },
      "execution_count": 1,
@@ -228,7 +228,7 @@
     {
      "data": {
       "text/plain": [
-       "['GRCh38:19', 'GRCh38:chr19']"
+       "['GRCh38:chr19', 'GRCh38:19']"
       ]
      },
      "execution_count": 9,
@@ -1500,10 +1500,19 @@
     "    location=rs429358_38,\n",
     "    state=models.LiteralSequenceExpression(sequence=\"C\")\n",
     ")\n",
-    "haplotype = models.Haplotype(\n",
-    "    members=[rs7412_38C, rs429358_38C]\n",
-    ")\n",
+    "haplotype = models.Haplotype(members=[rs7412_38C, rs429358_38C])\n",
     "output(haplotype)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# haplotype normalization puts members in a canonial order\n",
+    "haplotype2 = models.Haplotype(members=[rs429358_38C, rs7412_38C])\n",
+    "assert ga4gh_identify(normalize(haplotype)) == ga4gh_identify(normalize(haplotype2))"
    ]
   },
   {
@@ -1522,7 +1531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -1596,7 +1605,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -1646,7 +1655,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -1779,7 +1788,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -1788,7 +1797,7 @@
        "'z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXc'"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1799,7 +1808,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -1808,7 +1817,7 @@
        "'aKF498dAxcJAqme6QYQ7EZ07-fiw8Kw2'"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1828,7 +1837,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -1837,7 +1846,7 @@
        "b'{\"location\":\"u5fspwVbQ79QkX6GHLF8tXPCAXFJqRPx\",\"state\":{\"sequence\":\"T\",\"type\":\"SequenceState\"},\"type\":\"Allele\"}'"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1860,7 +1869,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -1869,7 +1878,7 @@
        "'EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH_'"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1881,7 +1890,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -1890,7 +1899,7 @@
        "'EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH_'"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1909,7 +1918,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -1918,7 +1927,7 @@
        "'ga4gh:VA.EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH_'"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/schema/y2j
+++ b/schema/y2j
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""convert yaml on stdin to json on stdout"""
 
 import json
 import sys
 import yaml
 
-# I randomly discovered that indent=3, sort_keys=True sorts $schema to
-# the top. I have no idea if that's intentional behavior.
 json.dump(yaml.load(sys.stdin, Loader=yaml.SafeLoader), sys.stdout, indent=3, sort_keys=False)

--- a/validation/models.yaml
+++ b/validation/models.yaml
@@ -1,10 +1,17 @@
-# Validation tests for objects
-# See notebooks/appendices/Validation%20Tests.ipynb
-
-# top-level keys are class names
-# in subkey contains key-value pairs of constructor arguments
-# out subkey contains key-value pairs of function and output
-
+Number:
+  -
+    in:
+      type: Number
+      value: 55
+    out:
+      ga4gh_serialize: '{"type":"Number","value":55}'
+Gene:
+  -
+    in:
+      gene_id: ncbigene:384
+      type: Gene
+    out:
+      ga4gh_serialize: '{"gene_id":"ncbigene:384","type":"Gene"}'
 SimpleInterval:
   -
     in:
@@ -13,56 +20,167 @@ SimpleInterval:
       type: SimpleInterval
     out:
       ga4gh_serialize: '{"end":44908822,"start":44908821,"type":"SimpleInterval"}'
-
-# NestedInterval:
-#   -
-#     in:
-#       inner:
-#         end: 44908821
-#         start: 44908796
-#         type: SimpleInterval
-#       outer:
-#         end: 44908847
-#         start: 44908822
-#         type: SimpleInterval
-#       type: NestedInterval
-#     out:
-#       ga4gh_serialize: '{"inner":{"end":44908821,"start":44908796,"type":"SimpleInterval"},"outer":{"end":44908847,"start":44908822,"type":"SimpleInterval"},"type":"NestedInterval"}'
-
+DefiniteRange:
+  -
+    in:
+      max: 33
+      min: 22
+      type: DefiniteRange
+    out:
+      ga4gh_serialize: '{"max":33,"min":22,"type":"DefiniteRange"}'
+IndefiniteRange:
+  -
+    in:
+      comparator: '>='
+      type: IndefiniteRange
+      value: 22
+    out:
+      ga4gh_serialize: '{"comparator":">=","type":"IndefiniteRange","value":22}'
+SequenceInterval:
+  -
+    in:
+      end:
+        type: Number
+        value: 44908822
+      start:
+        type: Number
+        value: 44908821
+      type: SequenceInterval
+    out:
+      ga4gh_serialize: '{"end":{"type":"Number","value":44908822},"start":{"type":"Number","value":44908821},"type":"SequenceInterval"}'
+SequenceInterval:
+  -
+    in:
+      end:
+        comparator: '>='
+        type: IndefiniteRange
+        value: 44908822
+      start:
+        max: 44908821
+        min: 44908721
+        type: DefiniteRange
+      type: SequenceInterval
+    out:
+      ga4gh_serialize: '{"end":{"comparator":">=","type":"IndefiniteRange","value":44908822},"start":{"max":44908821,"min":44908721,"type":"DefiniteRange"},"type":"SequenceInterval"}'
 SequenceLocation:
   -
     in:
       interval:
-        end: 44908822
-        start: 44908821
-        type: SimpleInterval
+        end:
+          type: Number
+          value: 44908822
+        start:
+          type: Number
+          value: 44908821
+        type: SequenceInterval
       sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
       type: SequenceLocation
     out:
-      ga4gh_serialize: '{"interval":{"end":44908822,"start":44908821,"type":"SimpleInterval"},"sequence_id":"IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl","type":"SequenceLocation"}'
-
+      ga4gh_digest: QrRSuBj-VScAGV_gEdxNgsnh41jYH1Kg
+      ga4gh_identify: ga4gh:VSL.QrRSuBj-VScAGV_gEdxNgsnh41jYH1Kg
+      ga4gh_serialize: '{"interval":{"end":{"type":"Number","value":44908822},"start":{"type":"Number","value":44908821},"type":"SequenceInterval"},"sequence_id":"IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl","type":"SequenceLocation"}'
 SequenceLocation:
   -
     in:
       interval:
-        end: 44908822
-        start: 44908821
-        type: SimpleInterval
+        end:
+          comparator: '>='
+          type: IndefiniteRange
+          value: 44908822
+        start:
+          max: 44908821
+          min: 44908721
+          type: DefiniteRange
+        type: SequenceInterval
       sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
       type: SequenceLocation
     out:
-      ga4gh_digest: u5fspwVbQ79QkX6GHLF8tXPCAXFJqRPx
-      ga4gh_identify: ga4gh:VSL.u5fspwVbQ79QkX6GHLF8tXPCAXFJqRPx
-      ga4gh_serialize: '{"interval":{"end":44908822,"start":44908821,"type":"SimpleInterval"},"sequence_id":"IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl","type":"SequenceLocation"}'
-
+      ga4gh_digest: 2ZIY16gPTLbVISuREaRmb0jXGj-_IdRv
+      ga4gh_identify: ga4gh:VSL.2ZIY16gPTLbVISuREaRmb0jXGj-_IdRv
+      ga4gh_serialize: '{"interval":{"end":{"comparator":">=","type":"IndefiniteRange","value":44908822},"start":{"max":44908821,"min":44908721,"type":"DefiniteRange"},"type":"SequenceInterval"},"sequence_id":"IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl","type":"SequenceLocation"}'
+CytobandInterval:
+  -
+    in:
+      end: q13.32
+      start: q13.32
+      type: CytobandInterval
+    out:
+      ga4gh_serialize: '{"end":"q13.32","start":"q13.32","type":"CytobandInterval"}'
+ChromosomeLocation:
+  -
+    in:
+      chr: '19'
+      interval:
+        end: q13.32
+        start: q13.32
+        type: CytobandInterval
+      species_id: taxonomy:9606
+      type: ChromosomeLocation
+    out:
+      ga4gh_digest: HLH0tBIjV4Vxr_814b41hBsICouJkSN1
+      ga4gh_identify: ga4gh:VCL.HLH0tBIjV4Vxr_814b41hBsICouJkSN1
+      ga4gh_serialize: '{"chr":"19","interval":{"end":"q13.32","start":"q13.32","type":"CytobandInterval"},"species_id":"taxonomy:9606","type":"ChromosomeLocation"}'
+DerivedSequenceExpression:
+  -
+    in:
+      location:
+        interval:
+          end:
+            type: Number
+            value: 44908822
+          start:
+            type: Number
+            value: 44908821
+          type: SequenceInterval
+        sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
+        type: SequenceLocation
+      reverse_complement: false
+      type: DerivedSequenceExpression
+    out:
+      ga4gh_serialize: '{"location":"QrRSuBj-VScAGV_gEdxNgsnh41jYH1Kg","reverse_complement":false,"type":"DerivedSequenceExpression"}'
+LiteralSequenceExpression:
+  -
+    in:
+      sequence: ACGT
+      type: LiteralSequenceExpression
+    out:
+      ga4gh_serialize: '{"sequence":"ACGT","type":"LiteralSequenceExpression"}'
+RepeatedSequenceExpression:
+  -
+    in:
+      count:
+        comparator: '>='
+        type: IndefiniteRange
+        value: 6
+      seq_expr:
+        location:
+          interval:
+            end:
+              type: Number
+              value: 44908822
+            start:
+              type: Number
+              value: 44908821
+            type: SequenceInterval
+          sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
+          type: SequenceLocation
+        reverse_complement: false
+        type: DerivedSequenceExpression
+      type: RepeatedSequenceExpression
+    out:
+      ga4gh_serialize: '{"count":{"comparator":">=","type":"IndefiniteRange","value":6},"seq_expr":{"location":"QrRSuBj-VScAGV_gEdxNgsnh41jYH1Kg","reverse_complement":false,"type":"DerivedSequenceExpression"},"type":"RepeatedSequenceExpression"}'
 Allele:
   -
     in:
       location:
         interval:
-          end: 44908822
-          start: 44908821
-          type: SimpleInterval
+          end:
+            type: Number
+            value: 44908822
+          start:
+            type: Number
+            value: 44908821
+          type: SequenceInterval
         sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
         type: SequenceLocation
       state:
@@ -70,18 +188,130 @@ Allele:
         type: SequenceState
       type: Allele
     out:
-      ga4gh_digest: EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH_
-      ga4gh_identify: ga4gh:VA.EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH_
-      ga4gh_serialize: '{"location":"u5fspwVbQ79QkX6GHLF8tXPCAXFJqRPx","state":{"sequence":"T","type":"SequenceState"},"type":"Allele"}'
-
+      ga4gh_digest: KnG6BLTexv7o-j9LnYsgPxZkRUu1IRnp
+      ga4gh_identify: ga4gh:VA.KnG6BLTexv7o-j9LnYsgPxZkRUu1IRnp
+      ga4gh_serialize: '{"location":"QrRSuBj-VScAGV_gEdxNgsnh41jYH1Kg","state":{"sequence":"T","type":"SequenceState"},"type":"Allele"}'
+Allele:
   -
     in:
-      location: ga4gh:VSL.u5fspwVbQ79QkX6GHLF8tXPCAXFJqRPx
+      location:
+        interval:
+          end:
+            type: Number
+            value: 44908822
+          start:
+            type: Number
+            value: 44908821
+          type: SequenceInterval
+        sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
+        type: SequenceLocation
       state:
         sequence: T
-        type: SequenceState
+        type: LiteralSequenceExpression
       type: Allele
     out:
-      ga4gh_digest: EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH_
-      ga4gh_identify: ga4gh:VA.EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH_
-      ga4gh_serialize: '{"location":"u5fspwVbQ79QkX6GHLF8tXPCAXFJqRPx","state":{"sequence":"T","type":"SequenceState"},"type":"Allele"}'
+      ga4gh_digest: CxiA_hvYbkD8Vqwjhx5AYuyul4mtlkpD
+      ga4gh_identify: ga4gh:VA.CxiA_hvYbkD8Vqwjhx5AYuyul4mtlkpD
+      ga4gh_serialize: '{"location":"QrRSuBj-VScAGV_gEdxNgsnh41jYH1Kg","state":{"sequence":"T","type":"LiteralSequenceExpression"},"type":"Allele"}'
+Haplotype:
+  -
+    in:
+      members:
+      - location:
+          interval:
+            end:
+              type: Number
+              value: 44908822
+            start:
+              type: Number
+              value: 44908821
+            type: SequenceInterval
+          sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
+          type: SequenceLocation
+        state:
+          sequence: C
+          type: LiteralSequenceExpression
+        type: Allele
+      - location:
+          interval:
+            end:
+              type: Number
+              value: 44908684
+            start:
+              type: Number
+              value: 44908683
+            type: SequenceInterval
+          sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
+          type: SequenceLocation
+        state:
+          sequence: C
+          type: LiteralSequenceExpression
+        type: Allele
+      type: Haplotype
+    out:
+      ga4gh_digest: i8owCOBHIlRCPtcw_WzRFNTunwJRy99-
+      ga4gh_identify: ga4gh:VH.i8owCOBHIlRCPtcw_WzRFNTunwJRy99-
+      ga4gh_serialize: '{"members":["-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x","Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1"],"type":"Haplotype"}'
+CopyNumber:
+  -
+    in:
+      copies:
+        comparator: '>='
+        type: IndefiniteRange
+        value: 3
+      subject:
+        gene_id: ncbigene:384
+        type: Gene
+      type: CopyNumber
+    out:
+      ga4gh_digest: xksSWn--_z28Qaj-Udlhot4OKqYGkywy
+      ga4gh_identify: ga4gh:VCN.xksSWn--_z28Qaj-Udlhot4OKqYGkywy
+      ga4gh_serialize: '{"copies":{"comparator":">=","type":"IndefiniteRange","value":3},"subject":{"gene_id":"ncbigene:384","type":"Gene"},"type":"CopyNumber"}'
+Text:
+  -
+    in:
+      definition: APOE loss
+      type: Text
+    out:
+      ga4gh_digest: 7hhlAaPeqj-sd67nSWXl7WC1yJ-g15tp
+      ga4gh_identify: ga4gh:VT.7hhlAaPeqj-sd67nSWXl7WC1yJ-g15tp
+      ga4gh_serialize: '{"definition":"APOE loss","type":"Text"}'
+VariationSet:
+  -
+    in:
+      members:
+      - location:
+          interval:
+            end:
+              type: Number
+              value: 44908822
+            start:
+              type: Number
+              value: 44908821
+            type: SequenceInterval
+          sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
+          type: SequenceLocation
+        state:
+          sequence: C
+          type: LiteralSequenceExpression
+        type: Allele
+      - location:
+          interval:
+            end:
+              type: Number
+              value: 44908684
+            start:
+              type: Number
+              value: 44908683
+            type: SequenceInterval
+          sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
+          type: SequenceLocation
+        state:
+          sequence: C
+          type: LiteralSequenceExpression
+        type: Allele
+      type: VariationSet
+    out:
+      ga4gh_digest: QLQXSNSIFlqNYWmQbw-YkfmexPi4NeDE
+      ga4gh_identify: ga4gh:VS.QLQXSNSIFlqNYWmQbw-YkfmexPi4NeDE
+      ga4gh_serialize: '{"members":["-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x","Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1"],"type":"VariationSet"}'


### PR DESCRIPTION
This branch contains validation tests for all non-abstract classes in VRS.
VRS python HEAD (as of d806dd4, but not earlier) executes these tests as-is.

Tests are framed around VRS classes. In this PR, each class has exactly one test, but having other tests is possible.

For each test, there is an output block that defines the expected output for zero or more functions.

So, for

```
Number:
  -
    in:
      type: Number
      value: 55
    out:
      ga4gh_serialize: '{"type":"Number","value":55}'

```

Interpret as: This test is for the class `Number`. There is one test (`-` is the start of an array). The `in` block defines the class attributes to create an instance. That instance is passed to `ga4gh_serialize`, which is expected to return the given string.