### PR TITLE
Closes #323: Update docs examples; split base classes and primitives; add missing docs 

### DIFF
--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -347,7 +347,9 @@ molecule.
 
 **Examples**
 
-An APOE ε2 Haplotype with inline Alleles::
+An APOE ε2 Haplotype with inline Alleles:
+
+.. parsed-literal::
 
     {
       "members": [
@@ -1544,8 +1546,161 @@ Absolute copy number counts may not be smaller than zero.
    }
 
 
-Primitive Concepts
-@@@@@@@@@@@@@@@@@@
+Base Classes
+@@@@@@@@@@@@
+
+Base classes are data structures that represent general concepts and
+that may be applicable in multiple parts of VRS.
+
+
+.. _DefiniteRange:
+
+DefiniteRange
+###############
+
+
+**Computational Definition**
+
+DefiniteRange represents an inclusive range of values.
+
+**Information Model**
+
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - type
+     - string
+     - 1..1
+     - MUST be "DefiniteRange"
+   * - min
+     - integer
+     - 1..1
+     - minimum value; inclusive
+   * - max
+     - integer
+     - 1..1
+     - maximum value; inclusive
+
+
+**Example**
+
+.. parsed-literal::
+
+    {
+      "max": 33,
+      "min": 22,
+      "type": "DefiniteRange"
+    }
+
+
+.. _IndefiniteRange:
+
+IndefiniteRange
+################
+
+
+**Computational Definition**
+
+IndefiniteRange represents an range of integer values, bounded on one
+side by negative infinity or positive infinity.
+
+**Information Model**
+
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - type
+     - string
+     - 1..1
+     - MUST be "IndefiniteRange"
+   * - value
+     - integer
+     - 1..1
+     - minimum value; inclusive
+   * - comparator
+     - string; enum ["<=", ">="]
+     - 1..1
+     - The range direction
+
+
+**Example**
+
+This value is equivalent to the concept of "equal to or greater than
+22":
+
+.. parsed-literal::
+
+    {
+      "comparator": ">=",
+      "type": "IndefiniteRange",
+      "value": 22
+    }
+
+
+.. _Number:
+
+Number
+#############
+
+
+**Computational Definition**
+
+A simple number.  This class exists primarily for parity with
+:ref:`DefiniteRange` and :ref:`IndefiniteRange`.
+
+
+**Information Model**
+
+.. list-table::
+   :class: reece-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   * - Field
+     - Type
+     - Limits
+     - Description
+   * - type
+     - string
+     - 1..1
+     - MUST be "Number"
+   * - value
+     - integer
+     - 1..1
+     - The integer values
+
+
+**Example**
+
+.. parsed-literal::
+
+    {
+      "type": "Number",
+      "value": 55
+    }
+
+
+
+Primitives
+@@@@@@@@@@
+
+Primitives represent simple values with syntactic or other
+constraints. They enable correctness for values stored in VRS.
 
 
 .. _CURIE:
@@ -1578,7 +1733,9 @@ A |curie| formatted string. A CURIE string has the structure
 
 **Examples**
 
-Identifiers for GRCh38 chromosome 19::
+Identifiers for GRCh38 chromosome 19:
+
+.. parsed-literal::
 
     ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
     refseq:NC_000019.10
@@ -1586,29 +1743,6 @@ Identifiers for GRCh38 chromosome 19::
 
 See :ref:`identify` for examples of CURIE-based identifiers for VRS
 objects.
-
-.. _DefiniteRange:
-
-DefiniteRange
-###############
-
-
-**Computational Definition**
-
-
-**Information Model**
-
-
-**Example**
-
-.. parsed-literal::
-
-    {
-      "max": 33,
-      "min": 22,
-      "type": "DefiniteRange"
-    }
-
 
 .. _HumanCytoband:
 
@@ -1637,53 +1771,9 @@ ISCN guidelines [1]_.
 
 **Example**
 
-"q13.32" (string)
-
-
-.. _IndefiniteRange:
-
-IndefiniteRange
-################
-
-
-**Computational Definition**
-
-
-**Information Model**
-
-
-**Example**
-
 .. parsed-literal::
 
-    {
-      "comparator": ">=",
-      "type": "IndefiniteRange",
-      "value": 22
-    }
-
-
-.. _Number:
-
-Number
-#############
-
-
-**Computational Definition**
-
-
-**Information Model**
-
-
-**Example**
-
-.. parsed-literal::
-
-    {
-      "type": "Number",
-      "value": 55
-    }
-
+   "q13.32" (string)
 
 
 .. _Residue:
@@ -1749,8 +1839,6 @@ derived from the IUPAC one-letter nucleic acid and amino acid codes.
 .. parsed-literal::
 
     "ACGT" (string)
-
-
 
 
 

--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -215,6 +215,8 @@ A state of a molecule at a :ref:`Location`.
 
 **Examples**
 
+An Allele correponding to rs7412 C>T on GRCh38:
+
 .. parsed-literal::
 
     {
@@ -345,7 +347,7 @@ molecule.
 
 **Examples**
 
-An APOE1 Haplotype with inline Alleles::
+An APOE ε2 Haplotype with inline Alleles::
 
     {
       "members": [
@@ -397,21 +399,23 @@ An APOE1 Haplotype with inline Alleles::
       "type": "Haplotype"
     }
 
-The same APOE-ε1 Haplotype with referenced Alleles::
+The same APOE ε2 Haplotype with referenced Alleles:
+  
+.. parsed-literal::
 
     {
       "members": [
-        "ga4gh:VA.iXjilHZiyCEoD3wVMPMXG3B8BtYfL88H",
-        "ga4gh:VA.EgHPXXhULTwoP4-ACfs-YCXaeUQJBjH_"
+        "ga4gh:VA.-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x",
+        "ga4gh:VA.Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1"
       ],
       "type": "Haplotype"
     }
 
 The GA4GH computed identifier for these Haplotypes is
-`ga4gh:VH.NAVnEuaP9gf41OxnPM56XxWQfdFNcUxJ`, regardless
-of whether the Variation objects are inlined or
-referenced, and regardless of order. See
-:ref:`computed-identifiers` for more information.
+``ga4gh:VH.i8owCOBHIlRCPtcw_WzRFNTunwJRy99-``, regardless of whether the
+Variation objects are inlined or referenced, and regardless of
+order. See :ref:`computed-identifiers` for more information.
+
 
 .. _SystemicVariation:
 
@@ -634,19 +638,77 @@ An unconstrained set of Variation members.
 
 **Examples**
 
+
+Example VariationSet with inline Alleles:
+
 .. parsed-literal::
 
-  {
-    "members": [
-      "ga4gh:VA.6xjH0Ikz88s7MhcyN5GJTa1p712-M10W",
-      "ga4gh:VA.7k2lyIsIsoBgRFPlfnIOeCeEgj_2BO7F",
-      "ga4gh:VA.ikcK330gH3bYO2sw9QcTsoptTFnk_Xjh"
-    ],
-    "type": "VariationSet"
-  }
+    {
+      "members": [
+        {
+          "location": {
+            "interval": {
+              "end": {
+                "type": "Number",
+                "value": 44908822
+              },
+              "start": {
+                "type": "Number",
+                "value": 44908821
+              },
+              "type": "SequenceInterval"
+            },
+            "sequence_id": "ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
+            "type": "SequenceLocation"
+          },
+          "state": {
+            "sequence": "C",
+            "type": "LiteralSequenceExpression"
+          },
+          "type": "Allele"
+        },
+        {
+          "location": {
+            "interval": {
+              "end": {
+                "type": "Number",
+                "value": 44908684
+              },
+              "start": {
+                "type": "Number",
+                "value": 44908683
+              },
+              "type": "SequenceInterval"
+            },
+            "sequence_id": "ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
+            "type": "SequenceLocation"
+          },
+          "state": {
+            "sequence": "C",
+            "type": "LiteralSequenceExpression"
+          },
+          "type": "Allele"
+        }
+      ],
+      "type": "VariationSet"
+    }
+
+
+The same VariationSet with referenced Alleles:
+
+.. parsed-literal::
+
+    {
+      "members": [
+        "ga4gh:VA.-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x",
+        "ga4gh:VA.Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1"
+      ],
+      "type": "VariationSet"
+    }
+
 
 The GA4GH computed identifier for these sets is
-`ga4gh:VS.WVC_R7OJ688EQX3NrgpJfsf_ctQUsVP3`, regardless of the whether
+``ga4gh:VS.QLQXSNSIFlqNYWmQbw-YkfmexPi4NeDE``, regardless of the whether
 the Variation objects are inlined or referenced, and regardless of
 order. See :ref:`computed-identifiers` for more information.
 
@@ -753,7 +815,8 @@ A :ref:`Location`, on a chromosome defined by a species and chromosome name.
   the syntactic structure of, `chromosome` depends on the species.
   `chromosome` MUST be an official sequence name from `NCBI Assembly
   <https://www.ncbi.nlm.nih.gov/assembly>`__.  For humans, valid
-  chromosome names are 1..22, X, Y (case-sensitive).
+  chromosome names are 1..22, X, Y (case-sensitive).  **NOTE: A `chr`
+  prefix is NOT part of the chromosome and MUST NOT be included.**
 * `interval` refers to a contiguous region specified named markers,
   which are presumed to exist on the specified chromosome.  See
   :ref:`CytobandInterval` for additional information.
@@ -777,16 +840,17 @@ A :ref:`Location`, on a chromosome defined by a species and chromosome name.
 
 .. parsed-literal::
 
-   {
-     "chr": "11",
-     "interval": {
-       "end": "q22.3",
-       "start": "q22.2",
-       "type": "CytobandInterval"
-       },
-     "species_id": "taxonomy:9606",
-     "type": "ChromosomeLocation"
-   }
+    {
+      "chr": "19",
+      "interval": {
+        "end": "q13.32",
+        "start": "q13.32",
+        "type": "CytobandInterval"
+      },
+      "species_id": "taxonomy:9606",
+      "type": "ChromosomeLocation"
+    }
+
 
 .. _SequenceLocation:
 
@@ -896,6 +960,22 @@ occurs. Any of these MAY be used as the SequenceInterval for Location.
 * `Interbase Coordinates (Chado documentation) <http://gmod.org/wiki/Introduction_to_Chado#Interbase_Coordinates>`__
 * `SequenceOntology: sequence_feature (SO:0000110) <http://www.sequenceontology.org/miso/current_svn/term/SO:0000110>`__ — Any extent of continuous biological sequence.
 * `SequenceOntology: region (SO:0000001) <http://www.sequenceontology.org/miso/current_svn/term/SO:0000001>`__ — A sequence_feature with an extent greater than zero. A nucleotide region is composed of bases and a polypeptide region is composed of amino acids.
+
+**Example**
+
+.. parsed-literal::
+
+    {
+      "end": {
+        "type": "Number",
+        "value": 44908822
+      },
+      "start": {
+        "type": "Number",
+        "value": 44908821
+      },
+      "type": "SequenceInterval"
+    }
 
 
 .. _SimpleInterval:
@@ -1107,11 +1187,12 @@ cytobands.
 
 .. parsed-literal::
 
-   {
-     "end": "p22.1",
-     "start": "p22.3",
-     "type": "CytobandInterval"
-   }
+    {
+      "end": "q13.32",
+      "start": "q13.32",
+      "type": "CytobandInterval"
+    }
+
 
 .. _SequenceExpression:
 
@@ -1214,20 +1295,27 @@ sequence location.
 
 .. parsed-literal::
 
-     {
-       "location": {
-         "interval": {
-           "end": 33,
-           "start": 22,
-           "type": "SimpleInterval"
-         },
-         "sequence_id": "ga4gh:SQ.0123abcd",
-         "type": "SequenceLocation"
-       },
-       "type": "DerivedSequenceExpression"
-     }
+    {
+      "location": {
+        "interval": {
+          "end": {
+            "type": "Number",
+            "value": 44908822
+          },
+          "start": {
+            "type": "Number",
+            "value": 44908821
+          },
+          "type": "SequenceInterval"
+        },
+        "sequence_id": "ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
+        "type": "SequenceLocation"
+      },
+      "reverse_complement": false,
+      "type": "DerivedSequenceExpression"
+    }
 
-
+    
 .. _RepeatedSequenceExpression:
 
 RepeatedSequenceExpression
@@ -1275,17 +1363,31 @@ An expression of a sequence comprised of a tandem repeating subsequence.
 
     {
       "count": {
-        "max": 10,
-        "min": 5,
-        "type": "AbsoluteCopyCount"
+        "comparator": ">=",
+        "type": "IndefiniteRange",
+        "value": 6
       },
       "seq_expr": {
-        "sequence": "CAG",
-        "type": "LiteralSequenceExpression"
+        "location": {
+          "interval": {
+            "end": {
+              "type": "Number",
+              "value": 44908822
+            },
+            "start": {
+              "type": "Number",
+              "value": 44908821
+            },
+            "type": "SequenceInterval"
+          },
+          "sequence_id": "ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
+          "type": "SequenceLocation"
+        },
+        "reverse_complement": false,
+        "type": "DerivedSequenceExpression"
       },
       "type": "RepeatedSequenceExpression"
     }
-
 
 
 .. _Feature:
@@ -1366,27 +1468,9 @@ The following examples all refer to the human BRCA1 gene:
 .. parsed-literal::
 
    {
-     'gene_id': 'ncbigene:672',
+     'gene_id': 'ncbigene:384',
      'type': 'Gene'
    }
-
-Gene is intended to be used as a subject of gene-level annotations,
-such as this statement of increased copy number of BRCA1:
-
-.. parsed-literal::
-
-    {
-      "copies": {
-        "min": 3,
-        "type": "AbsoluteCopyCount"
-      },
-      "subject": {
-        "gene_id": "ncbigene:672",
-        "type": "Gene"
-      },
-      "type": "AbsoluteCopyCount"
-    }
-
 
 
 **Sources**
@@ -1503,6 +1587,105 @@ Identifiers for GRCh38 chromosome 19::
 See :ref:`identify` for examples of CURIE-based identifiers for VRS
 objects.
 
+.. _DefiniteRange:
+
+DefiniteRange
+###############
+
+
+**Computational Definition**
+
+
+**Information Model**
+
+
+**Example**
+
+.. parsed-literal::
+
+    {
+      "max": 33,
+      "min": 22,
+      "type": "DefiniteRange"
+    }
+
+
+.. _HumanCytoband:
+
+HumanCytoband
+#############
+
+Cytobands are any of a pattern of stained bands, formed on chromosomes of
+cells undergoing metaphase, that serve to identify particular chromosomes.
+Human cytobands are predominantly specified by the *International System
+for Human Cytogenomic Nomenclature* (ISCN) [1]_.
+
+**Computational Definition**
+
+A character string representing cytobands derived from the
+*International System for Human Cytogenomic Nomenclature* (ISCN)
+guidelines.
+
+**Information Model**
+
+A string constrained to match the regular expression
+``^cen|[pq](ter|([1-9][0-9]*(\.[1-9][0-9]*)?))$``, derived from the
+ISCN guidelines [1]_.
+
+.. [1] McGowan-Jordan J (Ed.). *ISCN 2016: An international system
+       for human cytogenomic nomenclature (2016).* Karger (2016).
+
+**Example**
+
+"q13.32" (string)
+
+
+.. _IndefiniteRange:
+
+IndefiniteRange
+################
+
+
+**Computational Definition**
+
+
+**Information Model**
+
+
+**Example**
+
+.. parsed-literal::
+
+    {
+      "comparator": ">=",
+      "type": "IndefiniteRange",
+      "value": 22
+    }
+
+
+.. _Number:
+
+Number
+#############
+
+
+**Computational Definition**
+
+
+**Information Model**
+
+
+**Example**
+
+.. parsed-literal::
+
+    {
+      "type": "Number",
+      "value": 55
+    }
+
+
+
 .. _Residue:
 
 Residue
@@ -1561,30 +1744,14 @@ derived from the IUPAC one-letter nucleic acid and amino acid codes.
   necessary that Sequences be explicitly "typed" (i.e., DNA, RNA, or
   AA).
 
-.. _HumanCytoband:
+**Example**
 
-HumanCytoband
-#############
+.. parsed-literal::
 
-Cytobands are any of a pattern of stained bands, formed on chromosomes of
-cells undergoing metaphase, that serve to identify particular chromosomes.
-Human cytobands are predominantly specified by the *International System
-for Human Cytogenomic Nomenclature* (ISCN) [1]_.
+    "ACGT" (string)
 
-**Computational Definition**
 
-A character string representing cytobands derived from the
-*International System for Human Cytogenomic Nomenclature* (ISCN)
-guidelines.
 
-**Information Model**
-
-A string constrained to match the regular expression
-``^cen|[pq](ter|([1-9][0-9]*(\.[1-9][0-9]*)?))$``, derived from the
-ISCN guidelines [1]_.
-
-.. [1] McGowan-Jordan J (Ed.). *ISCN 2016: An international system
-       for human cytogenomic nomenclature (2016).* Karger (2016).
 
 
 .. _deprecations:

--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -218,20 +218,26 @@ A state of a molecule at a :ref:`Location`.
 .. parsed-literal::
 
     {
-       "location": {
-          "interval": {
-             "end": 44908822,
-             "start": 44908821,
-             "type": "SimpleInterval"
+      "location": {
+        "interval": {
+          "end": {
+            "type": "Number",
+            "value": 44908822
           },
-          "sequence_id": "ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
-          "type": "SequenceLocation"
-       },
-       "state": {
-          "sequence": "T",
-          "type": "LiteralSequenceExpression"
-       },
-       "type": "Allele"
+          "start": {
+            "type": "Number",
+            "value": 44908821
+          },
+          "type": "SequenceInterval"
+        },
+        "sequence_id": "ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
+        "type": "SequenceLocation"
+      },
+      "state": {
+        "sequence": "T",
+        "type": "SequenceState"
+      },
+      "type": "Allele"
     }
 
 
@@ -339,16 +345,22 @@ molecule.
 
 **Examples**
 
-An APOE-ε1 Haplotype with inline Alleles::
+An APOE1 Haplotype with inline Alleles::
 
     {
       "members": [
         {
           "location": {
             "interval": {
-              "end": 44908684,
-              "start": 44908683,
-              "type": "SimpleInterval"
+              "end": {
+                "type": "Number",
+                "value": 44908822
+              },
+              "start": {
+                "type": "Number",
+                "value": 44908821
+              },
+              "type": "SequenceInterval"
             },
             "sequence_id": "ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
             "type": "SequenceLocation"
@@ -362,15 +374,21 @@ An APOE-ε1 Haplotype with inline Alleles::
         {
           "location": {
             "interval": {
-              "end": 44908822,
-              "start": 44908821,
-              "type": "SimpleInterval"
+              "end": {
+                "type": "Number",
+                "value": 44908684
+              },
+              "start": {
+                "type": "Number",
+                "value": 44908683
+              },
+              "type": "SequenceInterval"
             },
             "sequence_id": "ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
             "type": "SequenceLocation"
           },
           "state": {
-            "sequence": "T",
+            "sequence": "C",
             "type": "LiteralSequenceExpression"
           },
           "type": "Allele"
@@ -466,12 +484,12 @@ Two, three, or four total copies of BRCA1:
 
     {
       "copies": {
-        "max": 4,
-        "min": 2,
-        "type": "AbsoluteCopyCount"
+        "comparator": ">=",
+        "type": "IndefiniteRange",
+        "value": 3
       },
       "subject": {
-        "gene_id": "ncbigene:672",
+        "gene_id": "ncbigene:384",
         "type": "Gene"
       },
       "type": "CopyNumber"
@@ -551,10 +569,9 @@ A free-text definition of variation.
 .. parsed-literal::
 
     {
-      "definition": "Microsatellite Instability High",
+      "definition": "APOE loss",
       "type": "Text"
     }
-
 
 .. _VariationSet:
 

--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -495,7 +495,7 @@ Two, three, or four total copies of BRCA1:
         "value": 3
       },
       "subject": {
-        "gene_id": "ncbigene:384",
+        "gene_id": "ncbigene:348",
         "type": "Gene"
       },
       "type": "CopyNumber"
@@ -1465,12 +1465,12 @@ regulatory, transcribed, and/or other functional Locations.
 
 **Examples**
 
-The following examples all refer to the human BRCA1 gene:
+The following examples all refer to the human APOE gene:
 
 .. parsed-literal::
 
    {
-     'gene_id': 'ncbigene:384',
+     'gene_id': 'ncbigene:348',
      'type': 'Gene'
    }
 

--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -482,7 +482,7 @@ The count of copies of a :ref:`Feature` or
      - 1..1
      - The integral number of copies of the subject in the genome
 
-**Example**
+**Examples**
 
 Two, three, or four total copies of BRCA1:
 
@@ -963,7 +963,7 @@ occurs. Any of these MAY be used as the SequenceInterval for Location.
 * `SequenceOntology: sequence_feature (SO:0000110) <http://www.sequenceontology.org/miso/current_svn/term/SO:0000110>`__ — Any extent of continuous biological sequence.
 * `SequenceOntology: region (SO:0000001) <http://www.sequenceontology.org/miso/current_svn/term/SO:0000001>`__ — A sequence_feature with an extent greater than zero. A nucleotide region is composed of bases and a polypeptide region is composed of amino acids.
 
-**Example**
+**Examples**
 
 .. parsed-literal::
 
@@ -1247,7 +1247,7 @@ An explicit expression of a Sequence.
      - 1..1
      - The sequence to express
 
-**Example**
+**Examples**
 
 .. parsed-literal::
 
@@ -1293,7 +1293,7 @@ sequence location.
      - 1..1
      - The location describing the sequence
 
-**Example**
+**Examples**
 
 .. parsed-literal::
 
@@ -1359,7 +1359,7 @@ An expression of a sequence comprised of a tandem repeating subsequence.
      - the inclusive range count of repeated units
 
 
-**Example**
+**Examples**
 
 .. parsed-literal::
 
@@ -1463,7 +1463,7 @@ regulatory, transcribed, and/or other functional Locations.
   implementation is not defined by this specification.
 * See discussion on :ref:`equivalence`.
 
-**Example**
+**Examples**
 
 The following examples all refer to the human BRCA1 gene:
 
@@ -1589,7 +1589,7 @@ DefiniteRange represents an inclusive range of values.
      - maximum value; inclusive
 
 
-**Example**
+**Examples**
 
 .. parsed-literal::
 
@@ -1637,7 +1637,7 @@ side by negative infinity or positive infinity.
      - The range direction
 
 
-**Example**
+**Examples**
 
 This value is equivalent to the concept of "equal to or greater than
 22":
@@ -1685,7 +1685,7 @@ A simple number.  This class exists primarily for parity with
      - The integer values
 
 
-**Example**
+**Examples**
 
 .. parsed-literal::
 
@@ -1769,7 +1769,7 @@ ISCN guidelines [1]_.
 .. [1] McGowan-Jordan J (Ed.). *ISCN 2016: An international system
        for human cytogenomic nomenclature (2016).* Karger (2016).
 
-**Example**
+**Examples**
 
 .. parsed-literal::
 
@@ -1834,7 +1834,7 @@ derived from the IUPAC one-letter nucleic acid and amino acid codes.
   necessary that Sequences be explicitly "typed" (i.e., DNA, RNA, or
   AA).
 
-**Example**
+**Examples**
 
 .. parsed-literal::
 

--- a/notebooks/Examples and Validation Tests.ipynb
+++ b/notebooks/Examples and Validation Tests.ipynb
@@ -22,27 +22,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Removing allOf attribute from CopyNumber to avoid pjs error.\n",
-      "Removing allOf attribute from SequenceInterval to avoid pjs error.\n",
-      "Removing allOf attribute from RepeatedSequenceExpression to avoid pjs error.\n",
-      "/home/reece/projects/ga4gh/vrs-python/venv/3.9/lib/python3.9/site-packages/python_jsonschema_objects/__init__.py:50: UserWarning: Schema version http://json-schema.org/draft-07/schema not recognized. Some keywords and features may not be supported.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "'0.7.0rc4.dev3+g3abb629.d20210620'"
+       "'0.7.0rc4.dev4+gd806dd4'"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -55,7 +44,7 @@
     "from IPython.display import display, Markdown\n",
     "\n",
     "from ga4gh.core import ga4gh_digest, ga4gh_identify, ga4gh_serialize, is_identifiable, sha512t24u\n",
-    "from ga4gh.vrs import __version__, models, normalize\n",
+    "from ga4gh.vrs import __version__, models, normalize, vrs_enref, vrs_deref\n",
     "__version__"
    ]
   },
@@ -228,7 +217,7 @@
     {
      "data": {
       "text/plain": [
-       "['GRCh38:chr19', 'GRCh38:19']"
+       "['GRCh38:19', 'GRCh38:chr19']"
       ]
      },
      "execution_count": 9,
@@ -393,117 +382,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Gene"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "**example object**\n",
-       "```\n",
-       "{\n",
-       "  \"gene_id\": \"ncbigene:384\",\n",
-       "  \"type\": \"Gene\"\n",
-       "}\n",
-       "```\n",
-       "\n",
-       "**validation test**\n",
-       "```\n",
-       "Gene:\n",
-       "  -\n",
-       "    in:\n",
-       "      gene_id: ncbigene:384\n",
-       "      type: Gene\n",
-       "    out:\n",
-       "      ga4gh_serialize: '{\"gene_id\":\"ncbigene:384\",\"type\":\"Gene\"}'\n",
-       "\n",
-       "```"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "gene = models.Gene(gene_id=\"ncbigene:384\")\n",
-    "output(gene)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Locations and Intervals"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### SimpleInterval (DEPRECATED)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "**example object**\n",
-       "```\n",
-       "{\n",
-       "  \"end\": 44908822,\n",
-       "  \"start\": 44908821,\n",
-       "  \"type\": \"SimpleInterval\"\n",
-       "}\n",
-       "```\n",
-       "\n",
-       "**validation test**\n",
-       "```\n",
-       "SimpleInterval:\n",
-       "  -\n",
-       "    in:\n",
-       "      end: 44908822\n",
-       "      start: 44908821\n",
-       "      type: SimpleInterval\n",
-       "    out:\n",
-       "      ga4gh_serialize: '{\"end\":44908822,\"start\":44908821,\"type\":\"SimpleInterval\"}'\n",
-       "\n",
-       "```"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "simple_interval = models.SimpleInterval(start=44908821, end=44908822)\n",
-    "output(simple_interval)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### DefiniteRange"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -550,12 +434,60 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Gene"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"gene_id\": \"ncbigene:384\",\n",
+       "  \"type\": \"Gene\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "Gene:\n",
+       "  -\n",
+       "    in:\n",
+       "      gene_id: ncbigene:384\n",
+       "      type: Gene\n",
+       "    out:\n",
+       "      ga4gh_serialize: '{\"gene_id\":\"ncbigene:384\",\"type\":\"Gene\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "gene = models.Gene(gene_id=\"ncbigene:384\")\n",
+    "output(gene)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### IndefiniteRange"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -596,6 +528,63 @@
     "  value=22,\n",
     "  comparator=\">=\")\n",
     "output(def_range)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Locations and Intervals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SimpleInterval (DEPRECATED)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"end\": 44908822,\n",
+       "  \"start\": 44908821,\n",
+       "  \"type\": \"SimpleInterval\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "SimpleInterval:\n",
+       "  -\n",
+       "    in:\n",
+       "      end: 44908822\n",
+       "      start: 44908821\n",
+       "      type: SimpleInterval\n",
+       "    out:\n",
+       "      ga4gh_serialize: '{\"end\":44908822,\"start\":44908821,\"type\":\"SimpleInterval\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "simple_interval = models.SimpleInterval(start=44908821, end=44908822)\n",
+    "output(simple_interval)"
    ]
   },
   {
@@ -1506,13 +1495,83 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
     "# haplotype normalization puts members in a canonial order\n",
     "haplotype2 = models.Haplotype(members=[rs429358_38C, rs7412_38C])\n",
     "assert ga4gh_identify(normalize(haplotype)) == ga4gh_identify(normalize(haplotype2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"members\": [\n",
+       "    \"ga4gh:VA.-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x\",\n",
+       "    \"ga4gh:VA.Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1\"\n",
+       "  ],\n",
+       "  \"type\": \"Haplotype\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "Haplotype:\n",
+       "  -\n",
+       "    in:\n",
+       "      members:\n",
+       "      - ga4gh:VA.-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x\n",
+       "      - ga4gh:VA.Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1\n",
+       "      type: Haplotype\n",
+       "    out:\n",
+       "      ga4gh_digest: i8owCOBHIlRCPtcw_WzRFNTunwJRy99-\n",
+       "      ga4gh_identify: ga4gh:VH.i8owCOBHIlRCPtcw_WzRFNTunwJRy99-\n",
+       "      ga4gh_serialize: '{\"members\":[\"-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x\",\"Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1\"],\"type\":\"Haplotype\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "object_store = {}\n",
+    "haplotype_ref= vrs_enref(haplotype, object_store)\n",
+    "output(haplotype_ref)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ga4gh:VH.i8owCOBHIlRCPtcw_WzRFNTunwJRy99-'"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "assert ga4gh_identify(haplotype) == ga4gh_identify(haplotype_ref)\n",
+    "ga4gh_identify(haplotype)"
    ]
   },
   {
@@ -1655,7 +1714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -1769,6 +1828,75 @@
    "source": [
     "variation_set = models.VariationSet(members=[rs7412_38C, rs429358_38C])\n",
     "output(variation_set)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**example object**\n",
+       "```\n",
+       "{\n",
+       "  \"members\": [\n",
+       "    \"ga4gh:VA.-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x\",\n",
+       "    \"ga4gh:VA.Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1\"\n",
+       "  ],\n",
+       "  \"type\": \"VariationSet\"\n",
+       "}\n",
+       "```\n",
+       "\n",
+       "**validation test**\n",
+       "```\n",
+       "VariationSet:\n",
+       "  -\n",
+       "    in:\n",
+       "      members:\n",
+       "      - ga4gh:VA.-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x\n",
+       "      - ga4gh:VA.Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1\n",
+       "      type: VariationSet\n",
+       "    out:\n",
+       "      ga4gh_digest: QLQXSNSIFlqNYWmQbw-YkfmexPi4NeDE\n",
+       "      ga4gh_identify: ga4gh:VS.QLQXSNSIFlqNYWmQbw-YkfmexPi4NeDE\n",
+       "      ga4gh_serialize: '{\"members\":[\"-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x\",\"Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1\"],\"type\":\"VariationSet\"}'\n",
+       "\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "variation_set_ref = vrs_enref(variation_set)\n",
+    "output(variation_set_ref)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ga4gh:VS.QLQXSNSIFlqNYWmQbw-YkfmexPi4NeDE'"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "assert ga4gh_identify(variation_set) == ga4gh_identify(variation_set_ref)\n",
+    "ga4gh_identify(variation_set)"
    ]
   },
   {

--- a/notebooks/Examples and Validation Tests.ipynb
+++ b/notebooks/Examples and Validation Tests.ipynb
@@ -253,7 +253,7 @@
     {
      "data": {
       "text/plain": [
-       "'ncbigene:384'"
+       "'ncbigene:348'"
       ]
      },
      "execution_count": 10,
@@ -262,7 +262,7 @@
     }
    ],
    "source": [
-    "curie = models.CURIE(\"ncbigene:384\")\n",
+    "curie = models.CURIE(\"ncbigene:348\")\n",
     "curie.for_json()"
    ]
   },
@@ -448,7 +448,7 @@
        "**example object**\n",
        "```\n",
        "{\n",
-       "  \"gene_id\": \"ncbigene:384\",\n",
+       "  \"gene_id\": \"ncbigene:348\",\n",
        "  \"type\": \"Gene\"\n",
        "}\n",
        "```\n",
@@ -458,10 +458,10 @@
        "Gene:\n",
        "  -\n",
        "    in:\n",
-       "      gene_id: ncbigene:384\n",
+       "      gene_id: ncbigene:348\n",
        "      type: Gene\n",
        "    out:\n",
-       "      ga4gh_serialize: '{\"gene_id\":\"ncbigene:384\",\"type\":\"Gene\"}'\n",
+       "      ga4gh_serialize: '{\"gene_id\":\"ncbigene:348\",\"type\":\"Gene\"}'\n",
        "\n",
        "```"
       ],
@@ -474,7 +474,7 @@
     }
    ],
    "source": [
-    "gene = models.Gene(gene_id=\"ncbigene:384\")\n",
+    "gene = models.Gene(gene_id=\"ncbigene:348\")\n",
     "output(gene)"
    ]
   },
@@ -1605,7 +1605,7 @@
        "    \"value\": 3\n",
        "  },\n",
        "  \"subject\": {\n",
-       "    \"gene_id\": \"ncbigene:384\",\n",
+       "    \"gene_id\": \"ncbigene:348\",\n",
        "    \"type\": \"Gene\"\n",
        "  },\n",
        "  \"type\": \"CopyNumber\"\n",
@@ -1622,13 +1622,13 @@
        "        type: IndefiniteRange\n",
        "        value: 3\n",
        "      subject:\n",
-       "        gene_id: ncbigene:384\n",
+       "        gene_id: ncbigene:348\n",
        "        type: Gene\n",
        "      type: CopyNumber\n",
        "    out:\n",
        "      ga4gh_digest: xksSWn--_z28Qaj-Udlhot4OKqYGkywy\n",
        "      ga4gh_identify: ga4gh:VCN.xksSWn--_z28Qaj-Udlhot4OKqYGkywy\n",
-       "      ga4gh_serialize: '{\"copies\":{\"comparator\":\">=\",\"type\":\"IndefiniteRange\",\"value\":3},\"subject\":{\"gene_id\":\"ncbigene:384\",\"type\":\"Gene\"},\"type\":\"CopyNumber\"}'\n",
+       "      ga4gh_serialize: '{\"copies\":{\"comparator\":\">=\",\"type\":\"IndefiniteRange\",\"value\":3},\"subject\":{\"gene_id\":\"ncbigene:348\",\"type\":\"Gene\"},\"type\":\"CopyNumber\"}'\n",
        "\n",
        "```"
       ],
@@ -1642,7 +1642,7 @@
    ],
    "source": [
     "copy_number = models.CopyNumber(\n",
-    "    subject=models.Gene(gene_id=\"ncbigene:384\"),\n",
+    "    subject=models.Gene(gene_id=\"ncbigene:348\"),\n",
     "    copies=models.IndefiniteRange(value=3, comparator=\">=\")\n",
     ")\n",
     "output(copy_number)"

--- a/validation/models.yaml
+++ b/validation/models.yaml
@@ -277,7 +277,7 @@ Text:
       ga4gh_identify: ga4gh:VT.7hhlAaPeqj-sd67nSWXl7WC1yJ-g15tp
       ga4gh_serialize: '{"definition":"APOE loss","type":"Text"}'
 VariationSet:
-  -
+  - name: VariationSet with referenced Alleles
     in:
       members:
       - location:
@@ -310,6 +310,16 @@ VariationSet:
           sequence: C
           type: LiteralSequenceExpression
         type: Allele
+      type: VariationSet
+    out:
+      ga4gh_digest: QLQXSNSIFlqNYWmQbw-YkfmexPi4NeDE
+      ga4gh_identify: ga4gh:VS.QLQXSNSIFlqNYWmQbw-YkfmexPi4NeDE
+      ga4gh_serialize: '{"members":["-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x","Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1"],"type":"VariationSet"}'
+  - name: VariationSet with inlined Alleles
+    in:
+      members:
+      - ga4gh:VA.-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x
+      - ga4gh:VA.Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1
       type: VariationSet
     out:
       ga4gh_digest: QLQXSNSIFlqNYWmQbw-YkfmexPi4NeDE

--- a/validation/models.yaml
+++ b/validation/models.yaml
@@ -1,19 +1,19 @@
 Number:
-  -
+  - 
     in:
       type: Number
       value: 55
     out:
       ga4gh_serialize: '{"type":"Number","value":55}'
 Gene:
-  -
+  - 
     in:
       gene_id: ncbigene:384
       type: Gene
     out:
       ga4gh_serialize: '{"gene_id":"ncbigene:384","type":"Gene"}'
 SimpleInterval:
-  -
+  - 
     in:
       end: 44908822
       start: 44908821
@@ -63,7 +63,7 @@ SequenceInterval:
     out:
       ga4gh_serialize: '{"end":{"comparator":">=","type":"IndefiniteRange","value":44908822},"start":{"max":44908821,"min":44908721,"type":"DefiniteRange"},"type":"SequenceInterval"}'
 SequenceLocation:
-  -
+  - name: "SequenceLocation w/simple interval"
     in:
       interval:
         end:
@@ -80,7 +80,7 @@ SequenceLocation:
       ga4gh_identify: ga4gh:VSL.QrRSuBj-VScAGV_gEdxNgsnh41jYH1Kg
       ga4gh_serialize: '{"interval":{"end":{"type":"Number","value":44908822},"start":{"type":"Number","value":44908821},"type":"SequenceInterval"},"sequence_id":"IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl","type":"SequenceLocation"}'
 SequenceLocation:
-  -
+  - name: "SequenceLocation w/Definite and Indefinite Ranges"
     in:
       interval:
         end:
@@ -107,7 +107,7 @@ CytobandInterval:
     out:
       ga4gh_serialize: '{"end":"q13.32","start":"q13.32","type":"CytobandInterval"}'
 ChromosomeLocation:
-  -
+  - name: "19q13.32 Example"
     in:
       chr: '19'
       interval:
@@ -170,7 +170,7 @@ RepeatedSequenceExpression:
     out:
       ga4gh_serialize: '{"count":{"comparator":">=","type":"IndefiniteRange","value":6},"seq_expr":{"location":"QrRSuBj-VScAGV_gEdxNgsnh41jYH1Kg","reverse_complement":false,"type":"DerivedSequenceExpression"},"type":"RepeatedSequenceExpression"}'
 Allele:
-  -
+  - name: "rs7412@GRCh38>T w/SequenceState"
     in:
       location:
         interval:
@@ -192,7 +192,7 @@ Allele:
       ga4gh_identify: ga4gh:VA.KnG6BLTexv7o-j9LnYsgPxZkRUu1IRnp
       ga4gh_serialize: '{"location":"QrRSuBj-VScAGV_gEdxNgsnh41jYH1Kg","state":{"sequence":"T","type":"SequenceState"},"type":"Allele"}'
 Allele:
-  -
+  - name: "rs7412@GRCh38>T w/LiteralSequenceExpression"
     in:
       location:
         interval:
@@ -214,7 +214,7 @@ Allele:
       ga4gh_identify: ga4gh:VA.CxiA_hvYbkD8Vqwjhx5AYuyul4mtlkpD
       ga4gh_serialize: '{"location":"QrRSuBj-VScAGV_gEdxNgsnh41jYH1Kg","state":{"sequence":"T","type":"LiteralSequenceExpression"},"type":"Allele"}'
 Haplotype:
-  -
+  - name: "APOE1 on GRCh38, inline"
     in:
       members:
       - location:
@@ -252,8 +252,18 @@ Haplotype:
       ga4gh_digest: i8owCOBHIlRCPtcw_WzRFNTunwJRy99-
       ga4gh_identify: ga4gh:VH.i8owCOBHIlRCPtcw_WzRFNTunwJRy99-
       ga4gh_serialize: '{"members":["-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x","Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1"],"type":"Haplotype"}'
+  - name: "APOE1 on GRCh38, referenced"
+    in:
+      members:
+      - ga4gh:VA.-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x
+      - ga4gh:VA.Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1
+      type: Haplotype
+    out:
+      ga4gh_digest: i8owCOBHIlRCPtcw_WzRFNTunwJRy99-
+      ga4gh_identify: ga4gh:VH.i8owCOBHIlRCPtcw_WzRFNTunwJRy99-
+      ga4gh_serialize: '{"members":["-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x","Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1"],"type":"Haplotype"}'
 CopyNumber:
-  -
+  - name: ">=3 copies APOE"
     in:
       copies:
         comparator: '>='
@@ -277,7 +287,7 @@ Text:
       ga4gh_identify: ga4gh:VT.7hhlAaPeqj-sd67nSWXl7WC1yJ-g15tp
       ga4gh_serialize: '{"definition":"APOE loss","type":"Text"}'
 VariationSet:
-  - name: VariationSet with referenced Alleles
+  - name: "VariationSet with referenced Alleles"
     in:
       members:
       - location:
@@ -315,7 +325,7 @@ VariationSet:
       ga4gh_digest: QLQXSNSIFlqNYWmQbw-YkfmexPi4NeDE
       ga4gh_identify: ga4gh:VS.QLQXSNSIFlqNYWmQbw-YkfmexPi4NeDE
       ga4gh_serialize: '{"members":["-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x","Z_rYRxpUvwqCLsCBO3YLl70o2uf9_Op1"],"type":"VariationSet"}'
-  - name: VariationSet with inlined Alleles
+  - name: "VariationSet with inlined Alleles"
     in:
       members:
       - ga4gh:VA.-kUJh47Pu24Y3Wdsk1rXEDKsXWNY-68x


### PR DESCRIPTION
1. Copy-pasted tests from `Notebooks/Examples and Validation Tests.ipynb` into all corresponding examples
2. Add docs for DefiniteRange, IndefiniteRange, and Number
3. Split Primitives (e.g., Residue and String) from Base Classes (e.g., Number, DefiniteRange).

Updated docs are here: https://vrs.ga4gh.org/en/323-update-examples/terms_and_model.html