### PR TITLE
revise copynumber.copies

### DIFF
--- a/schema/defs/vrs/CopyNumber.rst
+++ b/schema/defs/vrs/CopyNumber.rst
@@ -1,6 +1,6 @@
 **Computational Definition**
 
-The count of discrete copies of a subject :ref:`MolecularVariation`, :ref:`Feature`, :ref:`SequenceExpression`, or a :ref:`CURIE` reference to any of these.
+The absolute count of discrete copies of a :ref:`MolecularVariation`, :ref:`Feature`, :ref:`SequenceExpression`, or a :ref:`CURIE` reference within a system (e.g. genome, cell, etc.).
 
 **Information Model**
 
@@ -31,4 +31,4 @@ Some CopyNumber attributes are inherited from :ref:`Variation`.
    *  - copies
       - :ref:`Number` | :ref:`IndefiniteRange` | :ref:`DefiniteRange`
       - 1..1
-      - The integral number of copies of the subject in a genome
+      - The integral number of copies of the subject in a system

--- a/schema/defs/vrs/CytobandInterval.rst
+++ b/schema/defs/vrs/CytobandInterval.rst
@@ -1,6 +1,6 @@
 **Computational Definition**
 
-A contiguous region specified by cytobands. The region includes the constituent regions described by the start and end cytobands, as well as any intervening regions.
+A contiguous span on a chromosome defined by cytoband features. The span includes the constituent regions described by the start and end cytobands, as well as any intervening regions.
 
 **Information Model**
 

--- a/schema/defs/vrs/Number.rst
+++ b/schema/defs/vrs/Number.rst
@@ -1,6 +1,6 @@
 **Computational Definition**
 
-A simple number value as a VRS class.
+A simple integer value as a VRS class.
 
 **Information Model**
 
@@ -19,6 +19,6 @@ A simple number value as a VRS class.
       - 1..1
       - MUST be "Number"
    *  - value
-      - number
+      - integer
       - 1..1
       - The value represented by Number

--- a/schema/vrs-source.yaml
+++ b/schema/vrs-source.yaml
@@ -87,8 +87,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: ["Allele"]
-        default: "Allele"
+        const: "Allele"
         description: >-
           MUST be "Allele"
       location:
@@ -115,8 +114,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: ["Haplotype"]
-        default: "Haplotype"
+        const: "Haplotype"
         description: >-
           MUST be "Haplotype"
       members:
@@ -143,8 +141,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: ["Text"]
-        default: "Text"
+        const: "Text"
         description: MUST be "Text"
       definition:
         type: string
@@ -161,8 +158,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: ["VariationSet"]
-        default: "VariationSet"
+        const: "VariationSet"
         description: MUST be "VariationSet"
       members:
         type: array
@@ -190,8 +186,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: ["CopyNumber"]
-        default: "CopyNumber"
+        const: "CopyNumber"
         description: >-
           MUST be "CopyNumber"
       subject:
@@ -279,8 +274,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: ["ChromosomeLocation"]
-        default: "ChromosomeLocation"
+        const: "ChromosomeLocation"
         description: MUST be "ChromosomeLocation"
       species_id:
         $ref: "#/definitions/CURIE"
@@ -308,8 +302,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: ["SequenceLocation"]
-        default: "SequenceLocation"
+        const: "SequenceLocation"
         description: MUST be "SequenceLocation"
       sequence_id:
         $ref: "#/definitions/CURIE"
@@ -343,8 +336,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: [ "SequenceInterval" ]
-        default: "SequenceInterval"
+        const: "SequenceInterval"
         description: MUST be "SequenceInterval"
       start:
         oneOf:
@@ -451,8 +443,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: [ "CytobandInterval" ]
-        default: "CytobandInterval"
+        const: "CytobandInterval"
         description: MUST be "CytobandInterval"
       start:
         $ref: "#/definitions/HumanCytoband"
@@ -498,8 +489,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: ["LiteralSequenceExpression"]
-        default: "LiteralSequenceExpression"
+        const: "LiteralSequenceExpression"
         description: MUST be "LiteralSequenceExpression"
       sequence:
         $ref: "#/definitions/Sequence"
@@ -519,8 +509,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: ["DerivedSequenceExpression"]
-        default: "DerivedSequenceExpression"
+        const: "DerivedSequenceExpression"
         description: MUST be "DerivedSequenceExpression"
       location:
         $ref: "#/definitions/SequenceLocation"
@@ -541,8 +530,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: ["RepeatedSequenceExpression"]
-        default: "RepeatedSequenceExpression"
+        const: "RepeatedSequenceExpression"
         description: MUST be "RepeatedSequenceExpression"
       seq_expr:
         oneOf:
@@ -625,8 +613,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: ["Gene"]
-        default: "Gene"
+        const: "Gene"
         description: MUST be "Gene"
       gene_id:
         $ref: "#/definitions/CURIE"
@@ -645,8 +632,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: [ "Number" ]
-        default: "Number"
+        const: "Number"
         description: MUST be "Number"
       value:
         type: number
@@ -661,8 +647,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: [ "DefiniteRange" ]
-        default: "DefiniteRange"
+        const: "DefiniteRange"
         description: MUST be "DefiniteRange"
       min:
         type: number
@@ -683,8 +668,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: [ "IndefiniteRange" ]
-        default: "IndefiniteRange"
+        const: "IndefiniteRange"
         description: MUST be "IndefiniteRange"
       value:
         type: number
@@ -760,8 +744,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: ["SequenceState"]
-        default: "SequenceState"
+        const: "SequenceState"
         description: MUST be "SequenceState"
       sequence:
         $ref: "#/definitions/Sequence"
@@ -783,8 +766,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: ["SimpleInterval"]
-        default: "SimpleInterval"
+        const: "SimpleInterval"
         description: MUST be "SimpleInterval"
       start:
         type: integer

--- a/schema/vrs-source.yaml
+++ b/schema/vrs-source.yaml
@@ -203,7 +203,7 @@ definitions:
           - $ref: "#/definitions/IndefiniteRange"
           - $ref: "#/definitions/DefiniteRange"
         description: >-
-          The integral number of copies of the subject in a genome
+          The integral number of copies of the subject in a system
     allOf:
       - if:
           properties:

--- a/schema/vrs-source.yaml
+++ b/schema/vrs-source.yaml
@@ -180,9 +180,9 @@ definitions:
     additionalProperties: false
     type: object
     description: >-
-      The count of discrete copies of a subject :ref:`MolecularVariation`,
+      The absolute count of discrete copies of a :ref:`MolecularVariation`,
       :ref:`Feature`, :ref:`SequenceExpression`, or a :ref:`CURIE` reference
-      to any of these.
+      within a system (e.g. genome, cell, etc.).
     properties:
       type:
         type: string

--- a/schema/vrs-source.yaml
+++ b/schema/vrs-source.yaml
@@ -215,7 +215,6 @@ definitions:
               properties:
                 value:
                   minimum: 0
-                  type: integer
       - if:
           properties:
             copies:
@@ -226,7 +225,6 @@ definitions:
               properties:
                 value:
                   minimum: 0
-                  type: integer
       - if:
           properties:
             copies:
@@ -237,10 +235,8 @@ definitions:
               properties:
                 min:
                   minimum: 0
-                  type: integer
                 max:
                   minimum: 0
-                  type: integer
 
     required: [ "subject", "copies" ]
 
@@ -367,7 +363,6 @@ definitions:
               properties:
                 value:
                   minimum: 0
-                  type: integer
       - if:
           properties:
             start:
@@ -378,7 +373,6 @@ definitions:
               properties:
                 value:
                   minimum: 0
-                  type: integer
       - if:
           properties:
             start:
@@ -389,10 +383,8 @@ definitions:
               properties:
                 min:
                   minimum: 0
-                  type: integer
                 max:
                   minimum: 0
-                  type: integer
       - if:
           properties:
             end:
@@ -403,7 +395,6 @@ definitions:
               properties:
                 value:
                   minimum: 0
-                  type: integer
       - if:
           properties:
             end:
@@ -414,7 +405,6 @@ definitions:
               properties:
                 value:
                   minimum: 0
-                  type: integer
       - if:
           properties:
             end:
@@ -425,10 +415,8 @@ definitions:
               properties:
                 min:
                   minimum: 0
-                  type: integer
                 max:
                   minimum: 0
-                  type: integer
     required: [ "type", "start", "end" ]
 
   # SimpleInterval has been moved to DEPRECATED section at bottom.
@@ -556,7 +544,6 @@ definitions:
               properties:
                 value:
                   minimum: 0
-                  type: integer
       - if:
           properties:
             count:
@@ -567,7 +554,6 @@ definitions:
               properties:
                 value:
                   minimum: 0
-                  type: integer
       - if:
           properties:
             count:
@@ -578,10 +564,8 @@ definitions:
               properties:
                 min:
                   minimum: 0
-                  type: integer
                 max:
                   minimum: 0
-                  type: integer
     required: [ "seq_expr", "count" ]
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -626,7 +610,7 @@ definitions:
 
   Number:
     description: >-
-      A simple number value as a VRS class.
+      A simple integer value as a VRS class.
     type: object
     additionalProperties: false
     properties:
@@ -635,7 +619,7 @@ definitions:
         const: "Number"
         description: MUST be "Number"
       value:
-        type: number
+        type: integer
         description: The value represented by Number
     required: [ "type", "value" ]
 

--- a/schema/vrs-source.yaml
+++ b/schema/vrs-source.yaml
@@ -435,9 +435,9 @@ definitions:
 
   CytobandInterval:
     description: >-
-      A contiguous region specified by cytobands. The region includes
-      the constituent regions described by the start and end cytobands,
-      as well as any intervening regions.
+      A contiguous span on a chromosome defined by cytoband features.
+      The span includes the constituent regions described by the start and
+      end cytobands, as well as any intervening regions.
     type: object
     additionalProperties: false
     properties:

--- a/schema/vrs.json
+++ b/schema/vrs.json
@@ -205,7 +205,7 @@
       "CopyNumber": {
          "additionalProperties": false,
          "type": "object",
-         "description": "The count of discrete copies of a subject MolecularVariation, Feature, SequenceExpression, or a CURIE reference to any of these.",
+         "description": "The absolute count of discrete copies of a MolecularVariation, Feature, SequenceExpression, or a CURIE reference within a system (e.g. genome, cell, etc.).",
          "properties": {
             "_id": {
                "$ref": "#/definitions/CURIE",
@@ -245,7 +245,7 @@
                      "$ref": "#/definitions/DefiniteRange"
                   }
                ],
-               "description": "The integral number of copies of the subject in a genome"
+               "description": "The integral number of copies of the subject in a system"
             }
          },
          "allOf": [

--- a/schema/vrs.json
+++ b/schema/vrs.json
@@ -590,7 +590,7 @@
          ]
       },
       "CytobandInterval": {
-         "description": "A contiguous region specified by cytobands. The region includes the constituent regions described by the start and end cytobands, as well as any intervening regions.",
+         "description": "A contiguous span on a chromosome defined by cytoband features. The span includes the constituent regions described by the start and end cytobands, as well as any intervening regions.",
          "type": "object",
          "additionalProperties": false,
          "properties": {

--- a/schema/vrs.json
+++ b/schema/vrs.json
@@ -262,8 +262,7 @@
                      "copies": {
                         "properties": {
                            "value": {
-                              "minimum": 0,
-                              "type": "integer"
+                              "minimum": 0
                            }
                         }
                      }
@@ -283,8 +282,7 @@
                      "copies": {
                         "properties": {
                            "value": {
-                              "minimum": 0,
-                              "type": "integer"
+                              "minimum": 0
                            }
                         }
                      }
@@ -304,12 +302,10 @@
                      "copies": {
                         "properties": {
                            "min": {
-                              "minimum": 0,
-                              "type": "integer"
+                              "minimum": 0
                            },
                            "max": {
-                              "minimum": 0,
-                              "type": "integer"
+                              "minimum": 0
                            }
                         }
                      }
@@ -461,8 +457,7 @@
                      "start": {
                         "properties": {
                            "value": {
-                              "minimum": 0,
-                              "type": "integer"
+                              "minimum": 0
                            }
                         }
                      }
@@ -482,8 +477,7 @@
                      "start": {
                         "properties": {
                            "value": {
-                              "minimum": 0,
-                              "type": "integer"
+                              "minimum": 0
                            }
                         }
                      }
@@ -503,12 +497,10 @@
                      "start": {
                         "properties": {
                            "min": {
-                              "minimum": 0,
-                              "type": "integer"
+                              "minimum": 0
                            },
                            "max": {
-                              "minimum": 0,
-                              "type": "integer"
+                              "minimum": 0
                            }
                         }
                      }
@@ -528,8 +520,7 @@
                      "end": {
                         "properties": {
                            "value": {
-                              "minimum": 0,
-                              "type": "integer"
+                              "minimum": 0
                            }
                         }
                      }
@@ -549,8 +540,7 @@
                      "end": {
                         "properties": {
                            "value": {
-                              "minimum": 0,
-                              "type": "integer"
+                              "minimum": 0
                            }
                         }
                      }
@@ -570,12 +560,10 @@
                      "end": {
                         "properties": {
                            "min": {
-                              "minimum": 0,
-                              "type": "integer"
+                              "minimum": 0
                            },
                            "max": {
-                              "minimum": 0,
-                              "type": "integer"
+                              "minimum": 0
                            }
                         }
                      }
@@ -731,8 +719,7 @@
                      "count": {
                         "properties": {
                            "value": {
-                              "minimum": 0,
-                              "type": "integer"
+                              "minimum": 0
                            }
                         }
                      }
@@ -752,8 +739,7 @@
                      "count": {
                         "properties": {
                            "value": {
-                              "minimum": 0,
-                              "type": "integer"
+                              "minimum": 0
                            }
                         }
                      }
@@ -773,12 +759,10 @@
                      "count": {
                         "properties": {
                            "min": {
-                              "minimum": 0,
-                              "type": "integer"
+                              "minimum": 0
                            },
                            "max": {
-                              "minimum": 0,
-                              "type": "integer"
+                              "minimum": 0
                            }
                         }
                      }
@@ -824,7 +808,7 @@
          ]
       },
       "Number": {
-         "description": "A simple number value as a VRS class.",
+         "description": "A simple integer value as a VRS class.",
          "type": "object",
          "additionalProperties": false,
          "properties": {
@@ -834,7 +818,7 @@
                "description": "MUST be \"Number\""
             },
             "value": {
-               "type": "number",
+               "type": "integer",
                "description": "The value represented by Number"
             }
          },

--- a/schema/vrs.json
+++ b/schema/vrs.json
@@ -70,10 +70,7 @@
             },
             "type": {
                "type": "string",
-               "enum": [
-                  "Allele"
-               ],
-               "default": "Allele",
+               "const": "Allele",
                "description": "MUST be \"Allele\""
             },
             "location": {
@@ -121,10 +118,7 @@
             },
             "type": {
                "type": "string",
-               "enum": [
-                  "Haplotype"
-               ],
-               "default": "Haplotype",
+               "const": "Haplotype",
                "description": "MUST be \"Haplotype\""
             },
             "members": {
@@ -160,10 +154,7 @@
             },
             "type": {
                "type": "string",
-               "enum": [
-                  "Text"
-               ],
-               "default": "Text",
+               "const": "Text",
                "description": "MUST be \"Text\""
             },
             "definition": {
@@ -187,10 +178,7 @@
             },
             "type": {
                "type": "string",
-               "enum": [
-                  "VariationSet"
-               ],
-               "default": "VariationSet",
+               "const": "VariationSet",
                "description": "MUST be \"VariationSet\""
             },
             "members": {
@@ -225,10 +213,7 @@
             },
             "type": {
                "type": "string",
-               "enum": [
-                  "CopyNumber"
-               ],
-               "default": "CopyNumber",
+               "const": "CopyNumber",
                "description": "MUST be \"CopyNumber\""
             },
             "subject": {
@@ -363,10 +348,7 @@
             },
             "type": {
                "type": "string",
-               "enum": [
-                  "ChromosomeLocation"
-               ],
-               "default": "ChromosomeLocation",
+               "const": "ChromosomeLocation",
                "description": "MUST be \"ChromosomeLocation\""
             },
             "species_id": {
@@ -401,10 +383,7 @@
             },
             "type": {
                "type": "string",
-               "enum": [
-                  "SequenceLocation"
-               ],
-               "default": "SequenceLocation",
+               "const": "SequenceLocation",
                "description": "MUST be \"SequenceLocation\""
             },
             "sequence_id": {
@@ -436,10 +415,7 @@
          "properties": {
             "type": {
                "type": "string",
-               "enum": [
-                  "SequenceInterval"
-               ],
-               "default": "SequenceInterval",
+               "const": "SequenceInterval",
                "description": "MUST be \"SequenceInterval\""
             },
             "start": {
@@ -620,10 +596,7 @@
          "properties": {
             "type": {
                "type": "string",
-               "enum": [
-                  "CytobandInterval"
-               ],
-               "default": "CytobandInterval",
+               "const": "CytobandInterval",
                "description": "MUST be \"CytobandInterval\""
             },
             "start": {
@@ -670,10 +643,7 @@
          "properties": {
             "type": {
                "type": "string",
-               "enum": [
-                  "LiteralSequenceExpression"
-               ],
-               "default": "LiteralSequenceExpression",
+               "const": "LiteralSequenceExpression",
                "description": "MUST be \"LiteralSequenceExpression\""
             },
             "sequence": {
@@ -693,10 +663,7 @@
          "properties": {
             "type": {
                "type": "string",
-               "enum": [
-                  "DerivedSequenceExpression"
-               ],
-               "default": "DerivedSequenceExpression",
+               "const": "DerivedSequenceExpression",
                "description": "MUST be \"DerivedSequenceExpression\""
             },
             "location": {
@@ -721,10 +688,7 @@
          "properties": {
             "type": {
                "type": "string",
-               "enum": [
-                  "RepeatedSequenceExpression"
-               ],
-               "default": "RepeatedSequenceExpression",
+               "const": "RepeatedSequenceExpression",
                "description": "MUST be \"RepeatedSequenceExpression\""
             },
             "seq_expr": {
@@ -846,10 +810,7 @@
          "properties": {
             "type": {
                "type": "string",
-               "enum": [
-                  "Gene"
-               ],
-               "default": "Gene",
+               "const": "Gene",
                "description": "MUST be \"Gene\""
             },
             "gene_id": {
@@ -869,10 +830,7 @@
          "properties": {
             "type": {
                "type": "string",
-               "enum": [
-                  "Number"
-               ],
-               "default": "Number",
+               "const": "Number",
                "description": "MUST be \"Number\""
             },
             "value": {
@@ -892,10 +850,7 @@
          "properties": {
             "type": {
                "type": "string",
-               "enum": [
-                  "DefiniteRange"
-               ],
-               "default": "DefiniteRange",
+               "const": "DefiniteRange",
                "description": "MUST be \"DefiniteRange\""
             },
             "min": {
@@ -920,10 +875,7 @@
          "properties": {
             "type": {
                "type": "string",
-               "enum": [
-                  "IndefiniteRange"
-               ],
-               "default": "IndefiniteRange",
+               "const": "IndefiniteRange",
                "description": "MUST be \"IndefiniteRange\""
             },
             "value": {
@@ -979,10 +931,7 @@
          "properties": {
             "type": {
                "type": "string",
-               "enum": [
-                  "SequenceState"
-               ],
-               "default": "SequenceState",
+               "const": "SequenceState",
                "description": "MUST be \"SequenceState\""
             },
             "sequence": {
@@ -1007,10 +956,7 @@
          "properties": {
             "type": {
                "type": "string",
-               "enum": [
-                  "SimpleInterval"
-               ],
-               "default": "SimpleInterval",
+               "const": "SimpleInterval",
                "description": "MUST be \"SimpleInterval\""
             },
             "start": {

--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -352,9 +352,9 @@ definitions:
     - start
     - type
   CytobandInterval:
-    description: A contiguous region specified by cytobands. The region includes the
-      constituent regions described by the start and end cytobands, as well as any
-      intervening regions.
+    description: A contiguous span on a chromosome defined by cytoband features. The
+      span includes the constituent regions described by the start and end cytobands,
+      as well as any intervening regions.
     type: object
     additionalProperties: false
     properties:

--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -43,9 +43,7 @@ definitions:
         description: Variation Id. MUST be unique within document.
       type:
         type: string
-        enum:
-        - Allele
-        default: Allele
+        const: Allele
         description: MUST be "Allele"
       location:
         oneOf:
@@ -72,9 +70,7 @@ definitions:
       _id: *id001
       type:
         type: string
-        enum:
-        - Haplotype
-        default: Haplotype
+        const: Haplotype
         description: MUST be "Haplotype"
       members:
         type: array
@@ -97,9 +93,7 @@ definitions:
       _id: *id001
       type:
         type: string
-        enum:
-        - Text
-        default: Text
+        const: Text
         description: MUST be "Text"
       definition:
         type: string
@@ -116,9 +110,7 @@ definitions:
       _id: *id001
       type:
         type: string
-        enum:
-        - VariationSet
-        default: VariationSet
+        const: VariationSet
         description: MUST be "VariationSet"
       members:
         type: array
@@ -141,9 +133,7 @@ definitions:
       _id: *id001
       type:
         type: string
-        enum:
-        - CopyNumber
-        default: CopyNumber
+        const: CopyNumber
         description: MUST be "CopyNumber"
       subject:
         oneOf:
@@ -216,9 +206,7 @@ definitions:
         description: Location Id. MUST be unique within document.
       type:
         type: string
-        enum:
-        - ChromosomeLocation
-        default: ChromosomeLocation
+        const: ChromosomeLocation
         description: MUST be "ChromosomeLocation"
       species_id:
         $ref: '#/definitions/CURIE'
@@ -245,9 +233,7 @@ definitions:
       _id: *id002
       type:
         type: string
-        enum:
-        - SequenceLocation
-        default: SequenceLocation
+        const: SequenceLocation
         description: MUST be "SequenceLocation"
       sequence_id:
         $ref: '#/definitions/CURIE'
@@ -270,9 +256,7 @@ definitions:
     properties:
       type:
         type: string
-        enum:
-        - SequenceInterval
-        default: SequenceInterval
+        const: SequenceInterval
         description: MUST be "SequenceInterval"
       start:
         oneOf:
@@ -376,9 +360,7 @@ definitions:
     properties:
       type:
         type: string
-        enum:
-        - CytobandInterval
-        default: CytobandInterval
+        const: CytobandInterval
         description: MUST be "CytobandInterval"
       start:
         $ref: '#/definitions/HumanCytoband'
@@ -411,9 +393,7 @@ definitions:
     properties:
       type:
         type: string
-        enum:
-        - LiteralSequenceExpression
-        default: LiteralSequenceExpression
+        const: LiteralSequenceExpression
         description: MUST be "LiteralSequenceExpression"
       sequence:
         $ref: '#/definitions/Sequence'
@@ -432,9 +412,7 @@ definitions:
     properties:
       type:
         type: string
-        enum:
-        - DerivedSequenceExpression
-        default: DerivedSequenceExpression
+        const: DerivedSequenceExpression
         description: MUST be "DerivedSequenceExpression"
       location:
         $ref: '#/definitions/SequenceLocation'
@@ -454,9 +432,7 @@ definitions:
     properties:
       type:
         type: string
-        enum:
-        - RepeatedSequenceExpression
-        default: RepeatedSequenceExpression
+        const: RepeatedSequenceExpression
         description: MUST be "RepeatedSequenceExpression"
       seq_expr:
         oneOf:
@@ -527,9 +503,7 @@ definitions:
     properties:
       type:
         type: string
-        enum:
-        - Gene
-        default: Gene
+        const: Gene
         description: MUST be "Gene"
       gene_id:
         $ref: '#/definitions/CURIE'
@@ -544,9 +518,7 @@ definitions:
     properties:
       type:
         type: string
-        enum:
-        - Number
-        default: Number
+        const: Number
         description: MUST be "Number"
       value:
         type: number
@@ -561,9 +533,7 @@ definitions:
     properties:
       type:
         type: string
-        enum:
-        - DefiniteRange
-        default: DefiniteRange
+        const: DefiniteRange
         description: MUST be "DefiniteRange"
       min:
         type: number
@@ -585,9 +555,7 @@ definitions:
     properties:
       type:
         type: string
-        enum:
-        - IndefiniteRange
-        default: IndefiniteRange
+        const: IndefiniteRange
         description: MUST be "IndefiniteRange"
       value:
         type: number
@@ -643,9 +611,7 @@ definitions:
     properties:
       type:
         type: string
-        enum:
-        - SequenceState
-        default: SequenceState
+        const: SequenceState
         description: MUST be "SequenceState"
       sequence:
         $ref: '#/definitions/Sequence'
@@ -666,9 +632,7 @@ definitions:
     properties:
       type:
         type: string
-        enum:
-        - SimpleInterval
-        default: SimpleInterval
+        const: SimpleInterval
         description: MUST be "SimpleInterval"
       start:
         type: integer

--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -159,7 +159,6 @@ definitions:
             properties:
               value:
                 minimum: 0
-                type: integer
     - if:
         properties:
           copies:
@@ -170,7 +169,6 @@ definitions:
             properties:
               value:
                 minimum: 0
-                type: integer
     - if:
         properties:
           copies:
@@ -181,10 +179,8 @@ definitions:
             properties:
               min:
                 minimum: 0
-                type: integer
               max:
                 minimum: 0
-                type: integer
     required:
     - copies
     - subject
@@ -285,7 +281,6 @@ definitions:
             properties:
               value:
                 minimum: 0
-                type: integer
     - if:
         properties:
           start:
@@ -296,7 +291,6 @@ definitions:
             properties:
               value:
                 minimum: 0
-                type: integer
     - if:
         properties:
           start:
@@ -307,10 +301,8 @@ definitions:
             properties:
               min:
                 minimum: 0
-                type: integer
               max:
                 minimum: 0
-                type: integer
     - if:
         properties:
           end:
@@ -321,7 +313,6 @@ definitions:
             properties:
               value:
                 minimum: 0
-                type: integer
     - if:
         properties:
           end:
@@ -332,7 +323,6 @@ definitions:
             properties:
               value:
                 minimum: 0
-                type: integer
     - if:
         properties:
           end:
@@ -343,10 +333,8 @@ definitions:
             properties:
               min:
                 minimum: 0
-                type: integer
               max:
                 minimum: 0
-                type: integer
     required:
     - end
     - start
@@ -456,7 +444,6 @@ definitions:
             properties:
               value:
                 minimum: 0
-                type: integer
     - if:
         properties:
           count:
@@ -467,7 +454,6 @@ definitions:
             properties:
               value:
                 minimum: 0
-                type: integer
     - if:
         properties:
           count:
@@ -478,10 +464,8 @@ definitions:
             properties:
               min:
                 minimum: 0
-                type: integer
               max:
                 minimum: 0
-                type: integer
     required:
     - count
     - seq_expr
@@ -512,7 +496,7 @@ definitions:
     - gene_id
     - type
   Number:
-    description: A simple number value as a VRS class.
+    description: A simple integer value as a VRS class.
     type: object
     additionalProperties: false
     properties:
@@ -521,7 +505,7 @@ definitions:
         const: Number
         description: MUST be "Number"
       value:
-        type: number
+        type: integer
         description: The value represented by Number
     required:
     - type

--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -127,8 +127,9 @@ definitions:
   CopyNumber:
     additionalProperties: false
     type: object
-    description: The count of discrete copies of a subject MolecularVariation, Feature,
-      SequenceExpression, or a CURIE reference to any of these.
+    description: The absolute count of discrete copies of a MolecularVariation, Feature,
+      SequenceExpression, or a CURIE reference within a system (e.g. genome, cell,
+      etc.).
     properties:
       _id: *id001
       type:
@@ -147,7 +148,7 @@ definitions:
         - $ref: '#/definitions/Number'
         - $ref: '#/definitions/IndefiniteRange'
         - $ref: '#/definitions/DefiniteRange'
-        description: The integral number of copies of the subject in a genome
+        description: The integral number of copies of the subject in a system
     allOf:
     - if:
         properties:

--- a/tests/config.py
+++ b/tests/config.py
@@ -2,6 +2,6 @@ from pathlib import Path
 
 root_dir = Path(__file__).parent.parent
 schema_dir = root_dir / "schema"
-vrs_yaml_path = schema_dir / "vrs.yaml"
+vrs_yaml_path = schema_dir / "vrs-source.yaml"
 vrs_json_path = schema_dir / "vrs.json"
 


### PR DESCRIPTION
Aligns copynumber.copies with change in #374. Closes #360. Revises JSON check test to compare vrs-source YAML to JSON, instead of intermediate vrs YAML.