### PR TITLE
Fix Allele state type priority

### DIFF
--- a/schema/defs/vrs/ComposedSequenceExpression.rst
+++ b/schema/defs/vrs/ComposedSequenceExpression.rst
@@ -1,6 +1,6 @@
 **Computational Definition**
 
-An expression of a sequence composed from multiple other  :ref:`Sequence Expressions<SequenceExpression>`  objects. MUST have at least one component that is not a  ref:`LiteralSequenceExpression`. CANNOT be composed from  nested composed sequence expressions.
+An expression of a sequence composed from multiple other :ref:`Sequence Expressions<SequenceExpression>` objects. MUST have at least one component that is not a ref:`LiteralSequenceExpression`. CANNOT be composed from nested composed sequence expressions.
 
 **Information Model**
 
@@ -23,4 +23,4 @@ Some ComposedSequenceExpression attributes are inherited from :ref:`SequenceExpr
    *  - components
       - :ref:`LiteralSequenceExpression` | :ref:`RepeatedSequenceExpression` | :ref:`DerivedSequenceExpression`
       - 2..m
-      - An ordered list of :ref:`SequenceExpression` components   comprising the expression.
+      - An ordered list of :ref:`SequenceExpression` components comprising the expression.

--- a/schema/vrs-source.yaml
+++ b/schema/vrs-source.yaml
@@ -99,8 +99,8 @@ definitions:
           Where Allele is located
       state:
         oneOf:
-          - $ref: "#/definitions/SequenceState" # DEPRECATED; remove in 2.0
           - $ref: "#/definitions/SequenceExpression"
+          - $ref: "#/definitions/SequenceState" # DEPRECATED; remove in 2.0
         description: >-
           An expression of the sequence state
         deprecated:
@@ -602,10 +602,10 @@ definitions:
 
   ComposedSequenceExpression:
     description: >-
-      An expression of a sequence composed from multiple other 
-      :ref:`Sequence Expressions<SequenceExpression>` 
-      objects. MUST have at least one component that is not a 
-      ref:`LiteralSequenceExpression`. CANNOT be composed from 
+      An expression of a sequence composed from multiple other
+      :ref:`Sequence Expressions<SequenceExpression>`
+      objects. MUST have at least one component that is not a
+      ref:`LiteralSequenceExpression`. CANNOT be composed from
       nested composed sequence expressions.
     additionalProperties: false
     type: object
@@ -628,7 +628,7 @@ definitions:
             - $ref: "#/definitions/RepeatedSequenceExpression"
             - $ref: "#/definitions/DerivedSequenceExpression"
         description: >-
-          An ordered list of :ref:`SequenceExpression` components  
+          An ordered list of :ref:`SequenceExpression` components
           comprising the expression.
     required: [ "components" ]
 

--- a/schema/vrs.json
+++ b/schema/vrs.json
@@ -90,10 +90,10 @@
             "state": {
                "oneOf": [
                   {
-                     "$ref": "#/definitions/SequenceState"
+                     "$ref": "#/definitions/SequenceExpression"
                   },
                   {
-                     "$ref": "#/definitions/SequenceExpression"
+                     "$ref": "#/definitions/SequenceState"
                   }
                ],
                "description": "An expression of the sequence state",
@@ -834,7 +834,7 @@
          ]
       },
       "ComposedSequenceExpression": {
-         "description": "An expression of a sequence composed from multiple other  Sequence Expressions  objects. MUST have at least one component that is not a  ref:`LiteralSequenceExpression`. CANNOT be composed from  nested composed sequence expressions.",
+         "description": "An expression of a sequence composed from multiple other Sequence Expressions objects. MUST have at least one component that is not a ref:`LiteralSequenceExpression`. CANNOT be composed from nested composed sequence expressions.",
          "additionalProperties": false,
          "type": "object",
          "properties": {
@@ -870,7 +870,7 @@
                      }
                   ]
                },
-               "description": "An ordered list of SequenceExpression components   comprising the expression."
+               "description": "An ordered list of SequenceExpression components comprising the expression."
             }
          },
          "required": [

--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -53,8 +53,8 @@ definitions:
         description: Where Allele is located
       state:
         oneOf:
-        - $ref: '#/definitions/SequenceState'
         - $ref: '#/definitions/SequenceExpression'
+        - $ref: '#/definitions/SequenceState'
         description: An expression of the sequence state
         deprecated:
         - $ref: '#/definitions/SequenceState'
@@ -509,9 +509,9 @@ definitions:
     - seq_expr
     - type
   ComposedSequenceExpression:
-    description: An expression of a sequence composed from multiple other  Sequence
-      Expressions  objects. MUST have at least one component that is not a  ref:`LiteralSequenceExpression`.
-      CANNOT be composed from  nested composed sequence expressions.
+    description: An expression of a sequence composed from multiple other Sequence
+      Expressions objects. MUST have at least one component that is not a ref:`LiteralSequenceExpression`.
+      CANNOT be composed from nested composed sequence expressions.
     additionalProperties: false
     type: object
     properties:
@@ -532,8 +532,8 @@ definitions:
           oneOf:
           - $ref: '#/definitions/RepeatedSequenceExpression'
           - $ref: '#/definitions/DerivedSequenceExpression'
-        description: An ordered list of SequenceExpression components   comprising
-          the expression.
+        description: An ordered list of SequenceExpression components comprising the
+          expression.
     required:
     - components
     - type


### PR DESCRIPTION
The Allele's `state` property can either be a SequenceExpression or a SequenceState. The latter is deprecated, but was listed first, which means some implementing tools attempt to use it before trying SequenceExpressions (which causes some problems). Swapping the order solves the more immediate problem.