### PR TITLE
Add default value for types + update readme for using smoketests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ initiatives, and diagnostic testing laboratories.
 VRS is licensed under the [Apache License 2.0](LICENSE).
 
 
-> **NOTE:** VRS is under active development.  See [VR 
+> **NOTE:** VRS is under active development.  See [VR
 > Project Roadmap](https://github.com/orgs/ga4gh/projects/5).
 
 
@@ -67,12 +67,12 @@ To watch for changes and update automatically:
 
 The VR specification documentation is written in reStructuredText and
 located in `docs/source/`.  Commits to this repo are built
-automatically at `vrs.ga4gh.org`. 
+automatically at `vrs.ga4gh.org`.
 
 To build documentation locally, type:
 
     make -C docs clean watch &
-	
+
 Then, open `docs/build/html/index.html`.  The above make command
 should build docs when source changes. (Some types of changes require
 recleaning and building.)
@@ -95,7 +95,7 @@ The smoketests require python 3.8+. This is the recommended setup:
 $ python3 -m venv venv
 $ source venv/bin/activate
 $ pip install -U setuptools pip
-$ pip install -r requirements.txt
-$ pytest
+$ pip install -r .requirements.txt
+$ python3 -m pytest
 
 ```

--- a/schema/vrs-source.yaml
+++ b/schema/vrs-source.yaml
@@ -89,6 +89,7 @@ definitions:
       type:
         type: string
         const: "Allele"
+        default: "Allele"
         description: >-
           MUST be "Allele"
       location:
@@ -116,6 +117,7 @@ definitions:
       type:
         type: string
         const: "Haplotype"
+        default: "Haplotype"
         description: >-
           MUST be "Haplotype"
       members:
@@ -143,6 +145,7 @@ definitions:
       type:
         type: string
         const: "Text"
+        default: "Text"
         description: MUST be "Text"
       definition:
         type: string
@@ -160,6 +163,7 @@ definitions:
       type:
         type: string
         const: "VariationSet"
+        default: "VariationSet"
         description: MUST be "VariationSet"
       members:
         type: array
@@ -189,6 +193,7 @@ definitions:
       type:
         type: string
         const: "AbsoluteCopyNumber"
+        default: "AbsoluteCopyNumber"
         description: >-
           MUST be "AbsoluteCopyNumber"
       subject:
@@ -254,6 +259,7 @@ definitions:
       type:
         type: string
         const: "RelativeCopyNumber"
+        default: "RelativeCopyNumber"
         description: >-
           MUST be "RelativeCopyNumber"
       subject:
@@ -302,6 +308,7 @@ definitions:
       type:
         type: string
         const: "ChromosomeLocation"
+        default: "ChromosomeLocation"
         description: MUST be "ChromosomeLocation"
       species_id:
         $ref: "#/definitions/CURIE"
@@ -330,6 +337,7 @@ definitions:
       type:
         type: string
         const: "SequenceLocation"
+        default: "SequenceLocation"
         description: MUST be "SequenceLocation"
       sequence_id:
         $ref: "#/definitions/CURIE"
@@ -364,6 +372,7 @@ definitions:
       type:
         type: string
         const: "SequenceInterval"
+        default: "SequenceInterval"
         description: MUST be "SequenceInterval"
       start:
         oneOf:
@@ -463,6 +472,7 @@ definitions:
       type:
         type: string
         const: "CytobandInterval"
+        default: "CytobandInterval"
         description: MUST be "CytobandInterval"
       start:
         $ref: "#/definitions/HumanCytoband"
@@ -510,6 +520,7 @@ definitions:
       type:
         type: string
         const: "LiteralSequenceExpression"
+        default: "LiteralSequenceExpression"
         description: MUST be "LiteralSequenceExpression"
       sequence:
         $ref: "#/definitions/Sequence"
@@ -530,6 +541,7 @@ definitions:
       type:
         type: string
         const: "DerivedSequenceExpression"
+        default: "DerivedSequenceExpression"
         description: MUST be "DerivedSequenceExpression"
       location:
         $ref: "#/definitions/SequenceLocation"
@@ -551,6 +563,7 @@ definitions:
       type:
         type: string
         const: "RepeatedSequenceExpression"
+        default: "RepeatedSequenceExpression"
         description: MUST be "RepeatedSequenceExpression"
       seq_expr:
         oneOf:
@@ -613,6 +626,7 @@ definitions:
       type:
         type: string
         const: "ComposedSequenceExpression"
+        default: "ComposedSequenceExpression"
         description: MUST be "ComposedSequenceExpression"
       components:
         type: array
@@ -662,6 +676,7 @@ definitions:
       type:
         type: string
         const: "Gene"
+        default: "Gene"
         description: MUST be "Gene"
       gene_id:
         $ref: "#/definitions/CURIE"
@@ -681,6 +696,7 @@ definitions:
       type:
         type: string
         const: "Number"
+        default: "Number"
         description: MUST be "Number"
       value:
         type: integer
@@ -696,6 +712,7 @@ definitions:
       type:
         type: string
         const: "DefiniteRange"
+        default: "DefiniteRange"
         description: MUST be "DefiniteRange"
       min:
         type: number
@@ -717,6 +734,7 @@ definitions:
       type:
         type: string
         const: "IndefiniteRange"
+        default: "IndefiniteRange"
         description: MUST be "IndefiniteRange"
       value:
         type: number
@@ -793,6 +811,7 @@ definitions:
       type:
         type: string
         const: "SequenceState"
+        default: "SequenceState"
         description: MUST be "SequenceState"
       sequence:
         $ref: "#/definitions/Sequence"
@@ -815,6 +834,7 @@ definitions:
       type:
         type: string
         const: "SimpleInterval"
+        default: "SimpleInterval"
         description: MUST be "SimpleInterval"
       start:
         type: integer

--- a/schema/vrs.json
+++ b/schema/vrs.json
@@ -74,6 +74,7 @@
             "type": {
                "type": "string",
                "const": "Allele",
+               "default": "Allele",
                "description": "MUST be \"Allele\""
             },
             "location": {
@@ -122,6 +123,7 @@
             "type": {
                "type": "string",
                "const": "Haplotype",
+               "default": "Haplotype",
                "description": "MUST be \"Haplotype\""
             },
             "members": {
@@ -158,6 +160,7 @@
             "type": {
                "type": "string",
                "const": "Text",
+               "default": "Text",
                "description": "MUST be \"Text\""
             },
             "definition": {
@@ -182,6 +185,7 @@
             "type": {
                "type": "string",
                "const": "VariationSet",
+               "default": "VariationSet",
                "description": "MUST be \"VariationSet\""
             },
             "members": {
@@ -218,6 +222,7 @@
             "type": {
                "type": "string",
                "const": "AbsoluteCopyNumber",
+               "default": "AbsoluteCopyNumber",
                "description": "MUST be \"AbsoluteCopyNumber\""
             },
             "subject": {
@@ -336,6 +341,7 @@
             "type": {
                "type": "string",
                "const": "RelativeCopyNumber",
+               "default": "RelativeCopyNumber",
                "description": "MUST be \"RelativeCopyNumber\""
             },
             "subject": {
@@ -399,6 +405,7 @@
             "type": {
                "type": "string",
                "const": "ChromosomeLocation",
+               "default": "ChromosomeLocation",
                "description": "MUST be \"ChromosomeLocation\""
             },
             "species_id": {
@@ -434,6 +441,7 @@
             "type": {
                "type": "string",
                "const": "SequenceLocation",
+               "default": "SequenceLocation",
                "description": "MUST be \"SequenceLocation\""
             },
             "sequence_id": {
@@ -466,6 +474,7 @@
             "type": {
                "type": "string",
                "const": "SequenceInterval",
+               "default": "SequenceInterval",
                "description": "MUST be \"SequenceInterval\""
             },
             "start": {
@@ -639,6 +648,7 @@
             "type": {
                "type": "string",
                "const": "CytobandInterval",
+               "default": "CytobandInterval",
                "description": "MUST be \"CytobandInterval\""
             },
             "start": {
@@ -689,6 +699,7 @@
             "type": {
                "type": "string",
                "const": "LiteralSequenceExpression",
+               "default": "LiteralSequenceExpression",
                "description": "MUST be \"LiteralSequenceExpression\""
             },
             "sequence": {
@@ -709,6 +720,7 @@
             "type": {
                "type": "string",
                "const": "DerivedSequenceExpression",
+               "default": "DerivedSequenceExpression",
                "description": "MUST be \"DerivedSequenceExpression\""
             },
             "location": {
@@ -734,6 +746,7 @@
             "type": {
                "type": "string",
                "const": "RepeatedSequenceExpression",
+               "default": "RepeatedSequenceExpression",
                "description": "MUST be \"RepeatedSequenceExpression\""
             },
             "seq_expr": {
@@ -841,6 +854,7 @@
             "type": {
                "type": "string",
                "const": "ComposedSequenceExpression",
+               "default": "ComposedSequenceExpression",
                "description": "MUST be \"ComposedSequenceExpression\""
             },
             "components": {
@@ -897,6 +911,7 @@
             "type": {
                "type": "string",
                "const": "Gene",
+               "default": "Gene",
                "description": "MUST be \"Gene\""
             },
             "gene_id": {
@@ -917,6 +932,7 @@
             "type": {
                "type": "string",
                "const": "Number",
+               "default": "Number",
                "description": "MUST be \"Number\""
             },
             "value": {
@@ -937,6 +953,7 @@
             "type": {
                "type": "string",
                "const": "DefiniteRange",
+               "default": "DefiniteRange",
                "description": "MUST be \"DefiniteRange\""
             },
             "min": {
@@ -962,6 +979,7 @@
             "type": {
                "type": "string",
                "const": "IndefiniteRange",
+               "default": "IndefiniteRange",
                "description": "MUST be \"IndefiniteRange\""
             },
             "value": {
@@ -1018,6 +1036,7 @@
             "type": {
                "type": "string",
                "const": "SequenceState",
+               "default": "SequenceState",
                "description": "MUST be \"SequenceState\""
             },
             "sequence": {
@@ -1043,6 +1062,7 @@
             "type": {
                "type": "string",
                "const": "SimpleInterval",
+               "default": "SimpleInterval",
                "description": "MUST be \"SimpleInterval\""
             },
             "start": {

--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -45,6 +45,7 @@ definitions:
       type:
         type: string
         const: Allele
+        default: Allele
         description: MUST be "Allele"
       location:
         oneOf:
@@ -72,6 +73,7 @@ definitions:
       type:
         type: string
         const: Haplotype
+        default: Haplotype
         description: MUST be "Haplotype"
       members:
         type: array
@@ -95,6 +97,7 @@ definitions:
       type:
         type: string
         const: Text
+        default: Text
         description: MUST be "Text"
       definition:
         type: string
@@ -112,6 +115,7 @@ definitions:
       type:
         type: string
         const: VariationSet
+        default: VariationSet
         description: MUST be "VariationSet"
       members:
         type: array
@@ -137,6 +141,7 @@ definitions:
       type:
         type: string
         const: AbsoluteCopyNumber
+        default: AbsoluteCopyNumber
         description: MUST be "AbsoluteCopyNumber"
       subject:
         oneOf:
@@ -200,6 +205,7 @@ definitions:
       type:
         type: string
         const: RelativeCopyNumber
+        default: RelativeCopyNumber
         description: MUST be "RelativeCopyNumber"
       subject:
         oneOf:
@@ -240,6 +246,7 @@ definitions:
       type:
         type: string
         const: ChromosomeLocation
+        default: ChromosomeLocation
         description: MUST be "ChromosomeLocation"
       species_id:
         $ref: '#/definitions/CURIE'
@@ -267,6 +274,7 @@ definitions:
       type:
         type: string
         const: SequenceLocation
+        default: SequenceLocation
         description: MUST be "SequenceLocation"
       sequence_id:
         $ref: '#/definitions/CURIE'
@@ -290,6 +298,7 @@ definitions:
       type:
         type: string
         const: SequenceInterval
+        default: SequenceInterval
         description: MUST be "SequenceInterval"
       start:
         oneOf:
@@ -386,6 +395,7 @@ definitions:
       type:
         type: string
         const: CytobandInterval
+        default: CytobandInterval
         description: MUST be "CytobandInterval"
       start:
         $ref: '#/definitions/HumanCytoband'
@@ -420,6 +430,7 @@ definitions:
       type:
         type: string
         const: LiteralSequenceExpression
+        default: LiteralSequenceExpression
         description: MUST be "LiteralSequenceExpression"
       sequence:
         $ref: '#/definitions/Sequence'
@@ -439,6 +450,7 @@ definitions:
       type:
         type: string
         const: DerivedSequenceExpression
+        default: DerivedSequenceExpression
         description: MUST be "DerivedSequenceExpression"
       location:
         $ref: '#/definitions/SequenceLocation'
@@ -459,6 +471,7 @@ definitions:
       type:
         type: string
         const: RepeatedSequenceExpression
+        default: RepeatedSequenceExpression
         description: MUST be "RepeatedSequenceExpression"
       seq_expr:
         oneOf:
@@ -518,6 +531,7 @@ definitions:
       type:
         type: string
         const: ComposedSequenceExpression
+        default: ComposedSequenceExpression
         description: MUST be "ComposedSequenceExpression"
       components:
         type: array
@@ -555,6 +569,7 @@ definitions:
       type:
         type: string
         const: Gene
+        default: Gene
         description: MUST be "Gene"
       gene_id:
         $ref: '#/definitions/CURIE'
@@ -570,6 +585,7 @@ definitions:
       type:
         type: string
         const: Number
+        default: Number
         description: MUST be "Number"
       value:
         type: integer
@@ -585,6 +601,7 @@ definitions:
       type:
         type: string
         const: DefiniteRange
+        default: DefiniteRange
         description: MUST be "DefiniteRange"
       min:
         type: number
@@ -607,6 +624,7 @@ definitions:
       type:
         type: string
         const: IndefiniteRange
+        default: IndefiniteRange
         description: MUST be "IndefiniteRange"
       value:
         type: number
@@ -663,6 +681,7 @@ definitions:
       type:
         type: string
         const: SequenceState
+        default: SequenceState
         description: MUST be "SequenceState"
       sequence:
         $ref: '#/definitions/Sequence'
@@ -684,6 +703,7 @@ definitions:
       type:
         type: string
         const: SimpleInterval
+        default: SimpleInterval
         description: MUST be "SimpleInterval"
       start:
         type: integer


### PR DESCRIPTION
Ran tests in vrs-python (removed where we explicitly set `type` in the models) and everything passes 