### PR TITLE
C & P error fix in CytobandInterval

### DIFF
--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -403,7 +403,7 @@ definitions:
           end (telomere) of the chromosome p-arm than `end`.
       end:
         $ref: '#/definitions/HumanCytoband'
-        description: The start cytoband region. MUST specify a region nearer the terminal
+        description: The end cytoband region. MUST specify a region nearer the terminal
           end (telomere) of the chromosome q-arm than `start`.
     example:
       type: CytobandInterval


### PR DESCRIPTION
The description for `end` used `start` ... No code change.