### PR TITLE
fix: models.yaml to take ordered property in account

### DIFF
--- a/validation/models.yaml
+++ b/validation/models.yaml
@@ -427,7 +427,7 @@ GenotypeMember:
         type: Haplotype
       type: GenotypeMember
     out:
-     ga4gh_serialize: '{"count":{"type":"Number","value":1},"type":"GenotypeMember","variation":"746-M4L_EZL-CiduWjqODaYN26lTkEN1"}'
+     ga4gh_serialize: '{"count":{"type":"Number","value":1},"type":"GenotypeMember","variation":"Ow_uE0YaVWHIno4pQfdmYpWmlGPNtXQr"}'
 Genotype:
   -
     in:
@@ -459,20 +459,7 @@ Genotype:
             members:
             - location:
                 interval:
-                  end:
-                    type: Number
-                    value: 94761900
-                  start:
-                    type: Number
-                    value: 94761899
-                sequence_id: ga4gh:SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB
-                type: SequenceLocation
-              state:
-                sequence: T
-                type: LiteralSequenceExpression
-              type: Allele
-            - location:
-                interval:
+                  type: SequenceInterval
                   end:
                     type: Number
                     value: 94842866
@@ -485,6 +472,21 @@ Genotype:
                 sequence: G
                 type: LiteralSequenceExpression
               type: Allele
+            - location:
+                interval:
+                  type: SequenceInterval
+                  end:
+                    type: Number
+                    value: 94761900
+                  start:
+                    type: Number
+                    value: 94761899
+                sequence_id: ga4gh:SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB
+                type: SequenceLocation
+              state:
+                sequence: T
+                type: LiteralSequenceExpression
+              type: Allele
             type: Haplotype
           type: GenotypeMember
       count:
@@ -492,6 +494,6 @@ Genotype:
         value: 2
       type: Genotype
     out:
-      ga4gh_digest: wuTcSAvkSCHgpCAPOvt88K5VVyT6oEZ5
-      ga4gh_identify: ga4gh:GT.wuTcSAvkSCHgpCAPOvt88K5VVyT6oEZ5
-      ga4gh_serialize: '{"count":{"type":"Number","value":2},"members":[{"count":{"type":"Number","value":1},"type":"GenotypeMember","variation":"geQCxa1Enel8UBUAQQ2-rbphDjIR-cq0"},{"count":{"type":"Number","value":1},"type":"GenotypeMember","variation":"746-M4L_EZL-CiduWjqODaYN26lTkEN1"}],"type":"Genotype"}'
+      ga4gh_digest: CP6d8olj838oDLk5h0CbM_7DVK9kYcld
+      ga4gh_identify: ga4gh:GT.CP6d8olj838oDLk5h0CbM_7DVK9kYcld
+      ga4gh_serialize: '{"count":{"type":"Number","value":2},"members":[{"count":{"type":"Number","value":1},"type":"GenotypeMember","variation":"Ow_uE0YaVWHIno4pQfdmYpWmlGPNtXQr"},{"count":{"type":"Number","value":1},"type":"GenotypeMember","variation":"geQCxa1Enel8UBUAQQ2-rbphDjIR-cq0"}],"type":"Genotype"}'

--- a/validation/models.yaml
+++ b/validation/models.yaml
@@ -459,22 +459,6 @@ Genotype:
             members:
             - location:
                 interval:
-                  type: SequenceInterval
-                  end:
-                    type: Number
-                    value: 94842866
-                  start:
-                    type: Number
-                    value: 94842865
-                sequence_id: ga4gh:SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB
-                type: SequenceLocation
-              state:
-                sequence: G
-                type: LiteralSequenceExpression
-              type: Allele
-            - location:
-                interval:
-                  type: SequenceInterval
                   end:
                     type: Number
                     value: 94761900
@@ -487,6 +471,20 @@ Genotype:
                 sequence: T
                 type: LiteralSequenceExpression
               type: Allele
+            - location:
+                interval:
+                  end:
+                    type: Number
+                    value: 94842866
+                  start:
+                    type: Number
+                    value: 94842865
+                sequence_id: ga4gh:SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB
+                type: SequenceLocation
+              state:
+                sequence: G
+                type: LiteralSequenceExpression
+              type: Allele
             type: Haplotype
           type: GenotypeMember
       count:
@@ -494,6 +492,6 @@ Genotype:
         value: 2
       type: Genotype
     out:
-      ga4gh_digest: CP6d8olj838oDLk5h0CbM_7DVK9kYcld
-      ga4gh_identify: ga4gh:GT.CP6d8olj838oDLk5h0CbM_7DVK9kYcld
-      ga4gh_serialize: '{"count":{"type":"Number","value":2},"members":[{"count":{"type":"Number","value":1},"type":"GenotypeMember","variation":"Ow_uE0YaVWHIno4pQfdmYpWmlGPNtXQr"},{"count":{"type":"Number","value":1},"type":"GenotypeMember","variation":"geQCxa1Enel8UBUAQQ2-rbphDjIR-cq0"}],"type":"Genotype"}'
+      ga4gh_digest: fz-TMM88G2hmK6cQ-JwrpVAr8d_3eTVq
+      ga4gh_identify: ga4gh:GT.fz-TMM88G2hmK6cQ-JwrpVAr8d_3eTVq
+      ga4gh_serialize: '{"count":{"type":"Number","value":2},"members":["EhA9scQ-F-n1eQdQOJYClDXq613IZLQm","oJg9piBqrJ-_t3PSLA21d4z8f4tJHKqI"],"type":"Genotype"}'


### PR DESCRIPTION
Updating `models.yaml` to take into account the `ordered` property in array fields. 

The docs will be updated with this new rule in #410