### PR TITLE
Add tests to check schema validation in models.yaml (#406)

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,10 +1,12 @@
 import json
 
+import yaml
 import python_jsonschema_objects as pjs
 from schema.helpers import pjs_filter
 from ga4gh.gks.metaschema.tools.source_proc import YamlSchemaProcessor
+from jsonschema import validate, RefResolver
 
-from config import vrs_json_path, vrs_yaml_path
+from config import vrs_json_path, vrs_yaml_path, root_dir
 
 # Are the yaml and json parsable and do they match?
 p = YamlSchemaProcessor(vrs_yaml_path)
@@ -19,3 +21,16 @@ def test_json_yaml_match():
 def test_pjs_smoke():
     ob = pjs.ObjectBuilder(pjs_filter(j))
     assert ob.build_classes()              # no exception => okay
+
+
+def test_schema_validation():
+    """Test that examples in validation/models.yaml are valid"""
+    resolver = RefResolver.from_schema(j, store={"definitions": j})
+    schema_definitions = j["definitions"]
+    validation_models = root_dir / "validation" / "models.yaml"
+    validation_tests = yaml.load(open(validation_models), Loader=yaml.SafeLoader)
+    for cls, tests in validation_tests.items():
+        for t in tests:
+            validate(instance=t["in"],
+                     schema=schema_definitions[cls],
+                     resolver=resolver)

--- a/validation/models.yaml
+++ b/validation/models.yaml
@@ -404,6 +404,7 @@ GenotypeMember:
               start:
                 type: Number
                 value: 94761899
+              type: SequenceInterval
             sequence_id: ga4gh:SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB
             type: SequenceLocation
           state:
@@ -418,6 +419,7 @@ GenotypeMember:
               start:
                 type: Number
                 value: 94842865
+              type: SequenceInterval
             sequence_id: ga4gh:SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB
             type: SequenceLocation
           state:
@@ -465,6 +467,7 @@ Genotype:
                   start:
                     type: Number
                     value: 94761899
+                  type: SequenceInterval
                 sequence_id: ga4gh:SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB
                 type: SequenceLocation
               state:
@@ -479,6 +482,7 @@ Genotype:
                   start:
                     type: Number
                     value: 94842865
+                  type: SequenceInterval
                 sequence_id: ga4gh:SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB
                 type: SequenceLocation
               state:


### PR DESCRIPTION
Close #406

Before, we would find out that the examples in models.yaml were invalid through vrs-python tests. This added test will allow us to know in this repo 