### PR TITLE
relative_copy_class  -> copy_assessment in `CopyNumberChange` example

### DIFF
--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -427,7 +427,7 @@ Low-level copy gain of BRCA1:
 .. parsed-literal::
 
     {
-      "copy_assessment": "EFO_0030071", # low-level gain
+      "copy_change": "EFO_0030071", # low-level gain
       "subject": {
         "gene_id": "ncbigene:348",          # BRCA1 gene
         "type": "Gene"

--- a/docs/source/terms_and_model.rst
+++ b/docs/source/terms_and_model.rst
@@ -427,7 +427,7 @@ Low-level copy gain of BRCA1:
 .. parsed-literal::
 
     {
-      "relative_copy_class": "EFO_0030071", # low-level gain
+      "copy_assessment": "EFO_0030071", # low-level gain
       "subject": {
         "gene_id": "ncbigene:348",          # BRCA1 gene
         "type": "Gene"

--- a/schema/defs/vrs/CopyNumberChange.rst
+++ b/schema/defs/vrs/CopyNumberChange.rst
@@ -28,7 +28,7 @@ Some CopyNumberChange attributes are inherited from :ref:`Variation`.
       - :ref:`Location` | :ref:`CURIE` | :ref:`Feature`
       - 1..1
       - A location for which the number of systemic copies is described.
-   *  - copy_assessment
+   *  - copy_change
       - string
       - 1..1
       - MUST be one of "EFO_0030069" (complete genomic loss), "EFO_0020073" (high-level loss),  "EFO_0030068" (low-level loss), "EFO_0030067" (loss), "EFO_0030064" (regional base ploidy),  "EFO_0030070" (gain), "EFO_0030071" (low-level gain), "EFO_0030072" (high-level gain).

--- a/schema/vrs-source.yaml
+++ b/schema/vrs-source.yaml
@@ -238,14 +238,14 @@ definitions:
           - $ref: "#/definitions/Feature"
         description: >-
           A location for which the number of systemic copies is described.
-      copy_assessment:
+      copy_change:
         type: string
         enum: [ "EFO_0030069", "EFO_0020073", "EFO_0030068", "EFO_0030067", "EFO_0030064", "EFO_0030070", "EFO_0030071", "EFO_0030072" ]
         description: >-
           MUST be one of "EFO_0030069" (complete genomic loss), "EFO_0020073" (high-level loss), 
           "EFO_0030068" (low-level loss), "EFO_0030067" (loss), "EFO_0030064" (regional base ploidy), 
           "EFO_0030070" (gain), "EFO_0030071" (low-level gain), "EFO_0030072" (high-level gain).
-    required: [  "subject", "copy_assessment" ]
+    required: [  "subject", "copy_change" ]
 
   Genotype:
     inherits: SystemicVariation

--- a/schema/vrs.json
+++ b/schema/vrs.json
@@ -341,7 +341,7 @@
                ],
                "description": "A location for which the number of systemic copies is described."
             },
-            "copy_assessment": {
+            "copy_change": {
                "type": "string",
                "enum": [
                   "EFO_0030069",
@@ -357,7 +357,7 @@
             }
          },
          "required": [
-            "copy_assessment",
+            "copy_change",
             "subject",
             "type"
          ],

--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -204,7 +204,7 @@ definitions:
         - $ref: '#/definitions/Gene'
         - $ref: '#/definitions/SequenceLocation'
         description: A location for which the number of systemic copies is described.
-      copy_assessment:
+      copy_change:
         type: string
         enum:
         - EFO_0030069
@@ -220,7 +220,7 @@ definitions:
           "EFO_0030064" (regional base ploidy),  "EFO_0030070" (gain), "EFO_0030071"
           (low-level gain), "EFO_0030072" (high-level gain).
     required:
-    - copy_assessment
+    - copy_change
     - subject
     - type
     additionalProperties: false

--- a/validation/models.yaml
+++ b/validation/models.yaml
@@ -382,7 +382,7 @@ CopyNumberCount:
 CopyNumberChange:
   - name: "Low-level copy gain of BRCA1"
     in:
-      copy_assessment: EFO_0030071
+      copy_change: EFO_0030071
       subject:
         sequence_id: ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
         interval:
@@ -396,9 +396,9 @@ CopyNumberChange:
         type: SequenceLocation
       type: CopyNumberChange
     out:
-      ga4gh_digest: MLA_TGdelT-_jrlsC6N19S2itmcWqHfj
-      ga4gh_identify: ga4gh:CX.MLA_TGdelT-_jrlsC6N19S2itmcWqHfj
-      ga4gh_serialize: '{"copy_assessment":"EFO_0030071","subject":"oz3NEuhtbBep3yqu3wrhqfDKbLPK7vcE","type":"CopyNumberChange"}'
+      ga4gh_digest: W6Mr7EOuc8_oP--jzFqZeAj-ZC7pK9F_
+      ga4gh_identify: ga4gh:CX.W6Mr7EOuc8_oP--jzFqZeAj-ZC7pK9F_
+      ga4gh_serialize: '{"copy_change":"EFO_0030071","subject":"oz3NEuhtbBep3yqu3wrhqfDKbLPK7vcE","type":"CopyNumberChange"}'
 Text:
   -
     in:


### PR DESCRIPTION
IMO `relative_copy_class`  should be `copy_assessment` in the `CopyNumberChange` example?