### PR TITLE
Initial SV-VRS schema update

### DIFF
--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -73,6 +73,11 @@ definitions:
     - type
     additionalProperties: false
   Haplotype:
+    # For SV-VRS 'non-overlapping' is defined with respect to the
+    # derivate chromosome
+    # This allows SNVs within duplications to be reported as they
+    # can overlap in reference coordinate space, but not on the
+    # sample molecule.
     description: A set of non-overlapping Allele members that co-occur on the same
       molecule.
     type: object
@@ -88,12 +93,39 @@ definitions:
       members:
         type: array
         minItems: 2
-        uniqueItems: true
-        ordered: false
+        # By allowing repeats and defining an order on the
+        # members within a haplotype, we get a
+        # By allowing repeats within a Haplotype, we can now represent
+        # variants within SV. Notably, we can define SNVs that
+        # occur multiple times within a duplication.
+        uniqueItems: false
+        # The ordering of members within a Haplotype defines a traversal
+        # order for the derivate chromosome. This allows phasing of
+        # breakpoints as well as the Alleles between them.
+        # This is equivalent to the VCF phase set list (PSL) field
+        # with the VCF PSO field implicitly encoded in the member
+        # ordering within the Haplotype.
+        #
+        # Is this model appropriate? It doesn't support scenarios
+        # such as knowing two SNVs within a duplication are on the same
+        # molecule but not being able to place them to the first or
+        # second copy.
+        # (Note that the current VRS model does not support this
+        # scenario as the Alleles must be non-overlapping).
+        ordered: true
         items:
           oneOf:
           - $ref: '#/definitions/Allele'
           - $ref: '#/definitions/CURIE'
+          # Allowing Breakends and Breakpoints within Haplotypes
+          # is the lowest impact change to the existing VRS model.
+          # Conceptually, one might consider these to be Alleles,
+          # but they violate many of the assumptions that the existing
+          # Allele model has. Notably, breakpoints have two locations.
+          # Is this low-impact approach the best approach or should we
+          # be redefining Allele?
+          - $ref: '#/definitions/Breakpoint'
+          - $ref: '#/definitions/Breakend'
         description: List of Alleles, or references to Alleles, that comprise this
           Haplotype.
     required:
@@ -341,7 +373,7 @@ definitions:
         - $ref: '#/definitions/Number'
         description: The start coordinate or range of the interval. The minimum value
           of this coordinate or range is 0. MUST represent a coordinate or range less
-          than the value of `end`.
+          than or equal to the value of `end`.
       end:
         oneOf:
         - $ref: '#/definitions/DefiniteRange'
@@ -349,7 +381,7 @@ definitions:
         - $ref: '#/definitions/Number'
         description: The end coordinate or range of the interval. The minimum value
           of this coordinate or range is 0. MUST represent a coordinate or range greater
-          than the value of `start`.
+          than or equal to the value of `start`.
     required:
     - end
     - start
@@ -677,4 +709,118 @@ definitions:
     - end
     - start
     - type
+    additionalProperties: false
+  Breakend:
+    description:
+      "A break in a molecule with respect to a reference sequence indicating
+      the sequence deviates from the reference sequence after or before this
+      location."
+    type: object
+    properties:
+      type:
+        type: string
+        const: Breakend
+        default: Breakend
+        description: MUST be "Breakend"
+      location:
+        type: Location
+        description: The interval over which the break could occur in
+      orientation:
+        type: string
+        enum:
+          - DivergesAfter
+          - DivergesBefore
+        description:
+          MUST be one of "DivergesAfter" or "DivergesBefore" indicating whether the
+          sequences diverges from the reference after or before any position in the
+          interval.
+      # Does anyone have a need to support anything other than a LiteralSequenceExpression?
+      # I'd prefer not to as allowing reference-based sequences in here is just an
+      # alternate representation of multiple breaks and we want to minimise the number
+      # of different ways a sequence can be represented.
+      sequence:
+        type: LiteralSequenceExpression
+        description:
+          # TODO: clarify what this sequence is. We can define this as:
+          # - Traversal from the anchoring sequence (i.e RevComp DivergesBefore sequences)
+          # - Sequence prepend/concatenation
+          # TODO: What happens when the sequence itself has DerivedSequenceExpression.reverse_complement=true?
+          Sequence occuring after the break.
+      terminal:
+        # TODO: can the schema encode a constraint that a terminal breakend cannot
+        # be part of a breakpoint?
+        type: boolean
+        default: false
+        description: Indicates the end of the molecule
+    required:
+      - type
+      - location
+      - orientation
+    additionalProperties: false
+  Breakpoint:
+    description:
+      A rearrangement resulting in sequences flanking the two breakends becoming
+      adjacent sequences on the same molecule.
+    type: object
+    properties:
+      type:
+        type: string
+        const: Breakpoint
+        default: Breakpoint
+        description: MUST be "Breakpoint"
+      # I've taken the VCF-style model
+      # This is actually a lossy representation as many variant callers
+      # can constrain the actual location much more than anywhere in the
+      # [(start1, end1), (start2, end2)] range.
+      # for example, when the interval are due to homology, then the
+      # interval widths must be the same and, for any given position
+      # in the first breakend interval, there is only one possible position
+      # in the second breakend interval that is possible.
+      # Just specifying the two intervals independently as is done in this
+      # model does not intrinsically encode this information.
+      #
+      # Similarly, even imprecise calls have possibilities that are less
+      # likely than others. For example if a deletion break1 was at start1, then
+      # break2 might be constrained so something like [start2, start2 + (end2 - start2) / 3]
+      # because that would imply a longer deletion length that is plausible.
+      #
+      # VCF has a CILEN field that can encode this sort of information.
+      # Do we need an equivalent for VRS?
+      breakends:
+        type: array
+        uniqueItems: false
+        ordered: false
+        items:
+          type: Breakend
+        # TODO: how should the Breakend.sequence be interpreted?
+        # Option 1: be1 <-> seq1 <-> seq2 <-> be2
+        # That is, concatenate the sequences of both of them.
+        # Pros: no possibility of data inconsistency
+        # Cons: need to 'allocate' the sequence to one of the breakends
+        #
+        # Option2: be1 <-> seq <-> be2
+        # Pros: more intuitive interpretation
+        # Cons: possibility of data inconsistency (when seq1 != seq2)
+        description: Breakends involed in the sequence
+        minItems: 2
+        maxItems: 2
+      # Needed to support optical mapping gaps where the sequence between the
+      # breaks is not known but the approximate length is
+      insertion:
+        type: DefiniteRange
+        description: Approximate length of unknown sequence between the breaks.
+      homology:
+        # I've defined the homology
+        # TODO: this has the potential for data inconsistency
+        #is defining a homology
+        type: boolean
+        default: false
+        description:
+          A flag indicating whether the location interval of the breakend
+          is due to the sequences at the breakends being homologous or
+          whether the interval is due to uncertainty regarding the actual
+          locations of the breakends.
+    required:
+      - type
+      - breakends
     additionalProperties: false

--- a/schema/vrs.yaml
+++ b/schema/vrs.yaml
@@ -93,8 +93,6 @@ definitions:
       members:
         type: array
         minItems: 2
-        # By allowing repeats and defining an order on the
-        # members within a haplotype, we get a
         # By allowing repeats within a Haplotype, we can now represent
         # variants within SV. Notably, we can define SNVs that
         # occur multiple times within a duplication.
@@ -117,15 +115,7 @@ definitions:
           oneOf:
           - $ref: '#/definitions/Allele'
           - $ref: '#/definitions/CURIE'
-          # Allowing Breakends and Breakpoints within Haplotypes
-          # is the lowest impact change to the existing VRS model.
-          # Conceptually, one might consider these to be Alleles,
-          # but they violate many of the assumptions that the existing
-          # Allele model has. Notably, breakpoints have two locations.
-          # Is this low-impact approach the best approach or should we
-          # be redefining Allele?
           - $ref: '#/definitions/Breakpoint'
-          - $ref: '#/definitions/Breakend'
         description: List of Alleles, or references to Alleles, that comprise this
           Haplotype.
     required:
@@ -178,6 +168,7 @@ definitions:
           - $ref: '#/definitions/Haplotype'
           - $ref: '#/definitions/Text'
           - $ref: '#/definitions/VariationSet'
+          - $ref: '#/definitions/Breakpoint'
         description: List of Variation objects or identifiers. Attribute is required,
           but MAY be empty.
     required:
@@ -734,24 +725,6 @@ definitions:
           MUST be one of "DivergesAfter" or "DivergesBefore" indicating whether the
           sequences diverges from the reference after or before any position in the
           interval.
-      # Does anyone have a need to support anything other than a LiteralSequenceExpression?
-      # I'd prefer not to as allowing reference-based sequences in here is just an
-      # alternate representation of multiple breaks and we want to minimise the number
-      # of different ways a sequence can be represented.
-      sequence:
-        type: LiteralSequenceExpression
-        description:
-          # TODO: clarify what this sequence is. We can define this as:
-          # - Traversal from the anchoring sequence (i.e RevComp DivergesBefore sequences)
-          # - Sequence prepend/concatenation
-          # TODO: What happens when the sequence itself has DerivedSequenceExpression.reverse_complement=true?
-          Sequence occuring after the break.
-      terminal:
-        # TODO: can the schema encode a constraint that a terminal breakend cannot
-        # be part of a breakpoint?
-        type: boolean
-        default: false
-        description: Indicates the end of the molecule
     required:
       - type
       - location
@@ -792,17 +765,8 @@ definitions:
         ordered: false
         items:
           type: Breakend
-        # TODO: how should the Breakend.sequence be interpreted?
-        # Option 1: be1 <-> seq1 <-> seq2 <-> be2
-        # That is, concatenate the sequences of both of them.
-        # Pros: no possibility of data inconsistency
-        # Cons: need to 'allocate' the sequence to one of the breakends
-        #
-        # Option2: be1 <-> seq <-> be2
-        # Pros: more intuitive interpretation
-        # Cons: possibility of data inconsistency (when seq1 != seq2)
         description: Breakends involed in the sequence
-        minItems: 2
+        minItems: 1
         maxItems: 2
       # Needed to support optical mapping gaps where the sequence between the
       # breaks is not known but the approximate length is
@@ -810,9 +774,7 @@ definitions:
         type: DefiniteRange
         description: Approximate length of unknown sequence between the breaks.
       homology:
-        # I've defined the homology
-        # TODO: this has the potential for data inconsistency
-        #is defining a homology
+        # Only valid for breakends=2
         type: boolean
         default: false
         description:
@@ -820,7 +782,48 @@ definitions:
           is due to the sequences at the breakends being homologous or
           whether the interval is due to uncertainty regarding the actual
           locations of the breakends.
+      # Does anyone have a need to support anything other than a LiteralSequenceExpression?
+      # I'd prefer not to as allowing reference-based sequences in here is just an
+      # alternate representation of multiple breaks and we want to minimise the number
+      # of different ways a sequence can be represented.
+      sequence:
+        type: LiteralSequenceExpression
+        description:
+          # TODO: clarify what this sequence is. We can define this as:
+          # - Traversal from the anchoring sequence (i.e RevComp DivergesBefore sequences)
+          # - Sequence prepend/concatenation
+          # TODO: What happens when the sequence itself has DerivedSequenceExpression.reverse_complement=true?
+          Sequence occuring after the break.
+      terminal:
+        # TODO: can the schema encode a constraint that a terminal breakend cannot
+        # be part of a breakpoint?
+        type: boolean
+        default: false
+        description:
+          # Only valid for breakends=1
+          Indicates the end of the molecule
     required:
       - type
       - breakends
     additionalProperties: false
+  Event:
+    description:
+      An event that results in a set of variants.
+    type: object
+    properties:
+      type:
+        type: string
+        const: Event
+        default: Event
+        description: MUST be "Event"
+      variants:
+        $ref: '#/definitions/VariationSet'
+      classification:
+        # TODO: what event ontology should we use?
+        type: string
+        description: Category of event
+    required:
+      - type
+      - variants
+      - classification
+    additionalProperties: true


### PR DESCRIPTION
Initial SV-VRS Schema

# High-level design summary

- Breakend represent a change from reference to non-reference sequence at a given position
- Location encode any uncertainty in the position
- Breakpoint are composed on two (unordered) breakend
- Breakends can have literal sequence after the break
- SV-aware phasing is done by making Haplotype ordered and encoding the phasing in the allele ordering
- Allele remains untouched to minimise impact on the existing schema
- Zero-width Locations are allowed (to encode exact breakpoint positions)
- End-of-chromosome breakends are encoded in Breakend.terminal instead of VCF's approach of using placeholder breakends past the end of the chromosome
- CN untouched

# VCF equivalences:

SV-VRS | VCF
------|-----
Breakpoint | Two (redundant) ALT breakpoint records
Isolated Breakend | Single Breakend ALT allele notation
Terminal Breakend | Breakpoint past end of chromosome
Haplotype ordering | PSL/PSO fields
Breakend.sequence | Encoded in ALT^ for single breakends/(redundantly in) breakpoints
Breakpoint.insertion | Not supported

^ single breakend sequence must be at least one base otherwise it will be interpreted as the missing `.` allele.

# Clarifications needed

## ~~Is Location.end inclusive or exclusive?~~

~~That is, is `Location` encoded as [start, end] or [start, end)?~~

Location is start-end inclusive

## What is "non-overlapping Allele" in Haplotype defined with respect to?

Allowing duplication means that two copies of an Alelle can exist on the same molecule. For SV-VRS to work, the definition of 'non-overlapping' has to be with respect to the molecule, not w.r.t the reference. I don't think there's any problems with this subtle redefinition.

## What is the relationship between the reference and a haplotype?

The presence of an Allele/Haplotype defines a deviation w.r.t a reference. What (if anything) can be said about the reference outside of the Allele positions? Take the following example where there are 3 SNPs in a gene:

A) A SNP chip identifies and imputes phasing for SNPs at locations A, B and C. It reports a Haplotype containing three Alleles.

B) A WGS sequencing run finds the entire gene matches the reference except for these SNPs. It reports a Haplotype containing three Alleles.

C) A WES sequencing run finds the exons of the gene match the reference except for these SNPs. It reports a Haplotype containing three Alleles.

How does VRS differentiate these three scenarios? Does the CN of the gene impact this?

## How should Breakend.sequence be encoded?

- reverse complement on DivergesBefore?
- ~~reverse complement when DerivedSequenceExpression.reverse_complement=true?~~ (Not relevant: reverse_complement is not part of Location)


## Do we need a CILEN equivalent?

The breakpoint representation chosen is lossy w.r.t common variant calling types.
VCF has CILEN which encodes the range of expected lengths for simple SVs but has no equivalent for breakpoints.
This is actually a lossy representation as many variant callers
can constrain the actual location much more than anywhere in the
[(start1, end1), (start2, end2)] range.
for example, when the interval are due to homology, then the
interval widths must be the same and, for any given position
in the first breakend interval, there is only one possible position
in the second breakend interval that is possible.
Just specifying the two intervals independently as is done in this
model does not intrinsically encode this information (although for homology we can indeed define it as such since it's an unambiguous representation).

Similarly, even imprecise calls have possibilities that are less
likely than others. For example if a deletion break1 was at start1, then
break2 might be constrained so something like [start2, start2 + (end2 - start2) / 3]
because that would imply a longer deletion length that is plausible
(hence the VCF CILEN field).

Is there value in an equivalent field? Would anyone actually make any decisions differently if there was a narrower band of possible positions for an imprecise SV call?