### PR TITLE
fix: use camel case for copy change

### DIFF
--- a/schema/vrs-source.yaml
+++ b/schema/vrs-source.yaml
@@ -272,7 +272,7 @@ $defs:
     maturity: Alpha
     ga4ghDigest:
       keys:
-        - copy_change
+        - copyChange
       prefix: CX
     inherits: CopyNumber
     type: object
@@ -286,14 +286,14 @@ $defs:
         default: "CopyNumberChange"
         description: >-
           MUST be "CopyNumberChange"
-      copy_change:
+      copyChange:
         type: string
         enum: [ "efo:0030069", "efo:0020073", "efo:0030068", "efo:0030067", "efo:0030064", "efo:0030070", "efo:0030071", "efo:0030072" ]
         description: >-
           MUST be one of "efo:0030069" (complete genomic loss), "efo:0020073" (high-level loss),
           "efo:0030068" (low-level loss), "efo:0030067" (loss), "efo:0030064" (regional base ploidy),
           "efo:0030070" (gain), "efo:0030071" (low-level gain), "efo:0030072" (high-level gain).
-    required: [ "copy_change" ]
+    required: [ "copyChange" ]
 
   Genotype:
     maturity: Alpha


### PR DESCRIPTION
Initial work for #432 

@ahwagner I'm unable to run the `make all` commands due to errors. But wanted to update the case since it will affect digests