### PR TITLE
docs: fix typos and clean up table

### DIFF
--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -10,6 +10,11 @@
    table.reece-wrap {
       overflow: visible !important;
    }
+
+  .wy-table-responsive table.reece-wrap td, .wy-table-responsive table.reece-wrap th {
+      white-space: normal;
+  }
+
 }
 
 
@@ -60,9 +65,9 @@ div.figure div.legend p {
 div.figure div.legend p:last-child {
     margin-bottom: 0px;
 }
-    
 
-/* nested ul leads to awkward spacing of list items. 
+
+/* nested ul leads to awkward spacing of list items.
    This change doesn't seem to induce any other odd spacing */
 .rst-content .section ul p {
     margin-bottom: 0px;

--- a/docs/source/conventions/required_data.rst
+++ b/docs/source/conventions/required_data.rst
@@ -24,24 +24,23 @@ Contexts
 
 * **Conversion to other variant formats** When converting to other
   variation formats, implementations SHOULD translate GA4GH VR
-  sequence identifier ( ``ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_``)
+  sequence identifiers ( ``ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_``)
   to primary database identifiers (``refseq:NM_000551.3``) that will
   be more readily recognized by users.
 
 * **Normalization** During :ref:`normalization`, implementations will
-  need access to sequence length and sequence contexts. 
+  need access to sequence length and sequence contexts.
 
 
 
 Data Services
 @@@@@@@@@@@@@
 
-The following tables summarizes data required in the above contexts:
+The following table summarizes data required in the above contexts:
 
 .. list-table:: Data Service Desciptions
-   :class: reece-wrap
-   :widths: auto
    :header-rows: 1
+   :class: reece-wrap
 
    * - Data Service
      - Description


### PR DESCRIPTION
* fix a couple minor typos
* hacky, but widely-accepted, fix to [known RTD theme inability to wrap text in list-tables](https://github.com/readthedocs/sphinx_rtd_theme/issues/1505)

Before (took me a sec to realize that you could even scroll!): 

![Screenshot 2024-05-13 at 8 59 24 AM](https://github.com/ga4gh/vrs/assets/12942397/0027fdb0-a0d8-4bb7-98f9-9a3da421b6bf)

After

![Screenshot 2024-05-13 at 9 06 12 AM](https://github.com/ga4gh/vrs/assets/12942397/263138ca-19d0-44fa-bdcb-84a70a153077)