### PR TITLE
revert!: add back ga4ghDigest.assigned to SequenceReference

### DIFF
--- a/schema/vrs/json/SequenceReference
+++ b/schema/vrs/json/SequenceReference
@@ -5,9 +5,7 @@
    "type": "object",
    "maturity": "draft",
    "ga4ghDigest": {
-      "keys": [
-         "refgetAccession"
-      ]
+      "assigned": true
    },
    "description": "A sequence of nucleic or amino acid character codes.",
    "properties": {

--- a/schema/vrs/vrs-source.yaml
+++ b/schema/vrs/vrs-source.yaml
@@ -297,8 +297,9 @@ $defs:
     maturity: draft
     inherits: ValueObject
     ga4ghDigest:
-      keys:
-        - refgetAccession
+      assigned: true # This special property indicates that the `digest` field follows an alternate convention
+                # and is expected to have the value assigned following that convention. For SequenceReference,
+                # it is expected the digest will be the refget accession value without the `SQ.` prefix.
     type: object
     description: A sequence of nucleic or amino acid character codes.
     properties:


### PR DESCRIPTION
* Temporarily reverts changes made for #479 until we can discuss this further. Adding back assigned makes it clear that we are not computing a digest using provided keys