### PR TITLE
fix: resolve `SequenceReference` digest keys

### DIFF
--- a/schema/vrs/def/ValueObject.rst
+++ b/schema/vrs/def/ValueObject.rst
@@ -1,3 +1,3 @@
 **Computational Definition**
 
-A contextual value whose equality is based on value, not identity. See https://en.wikipedia.org/wiki/Value_object for more on Value Objects.
+A contextual value whose equality is based on value, not identity. These objects can be serialized but not digested for parent object serialization. See https://en.wikipedia.org/wiki/Value_object for more on Value Objects.

--- a/schema/vrs/json/SequenceReference
+++ b/schema/vrs/json/SequenceReference
@@ -5,7 +5,10 @@
    "type": "object",
    "maturity": "draft",
    "ga4ghDigest": {
-      "assigned": true
+      "keys": [
+         "refgetAccession",
+         "type"
+      ]
    },
    "description": "A sequence of nucleic or amino acid character codes.",
    "properties": {

--- a/schema/vrs/vrs-source.yaml
+++ b/schema/vrs/vrs-source.yaml
@@ -33,6 +33,7 @@ $defs:
     inherits: gks.core:DomainEntity
     description: >-
       A contextual value whose equality is based on value, not identity.
+      These objects can be serialized but not digested for parent object serialization.
       See https://en.wikipedia.org/wiki/Value_object for more on Value Objects.
 
   Ga4ghIdentifiableObject:
@@ -297,9 +298,10 @@ $defs:
     maturity: draft
     inherits: ValueObject
     ga4ghDigest:
-      assigned: true # This special property indicates that the `digest` field follows an alternate convention
-                # and is expected to have the value assigned following that convention. For SequenceReference,
-                # it is expected the digest will be the refget accession value without the `SQ.` prefix.
+      keys: [
+        "refgetAccession",
+        "type"
+      ]
     type: object
     description: A sequence of nucleic or amino acid character codes.
     properties:

--- a/validation/models.yaml
+++ b/validation/models.yaml
@@ -6,7 +6,7 @@ SequenceReference:
     out:
       ga4gh_identify: null
       ga4gh_digest: null
-      ga4gh_serialize: '{"refgetAccession":"SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"}'
+      ga4gh_serialize: '{"refgetAccession":"SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul","type":"SequenceReference"}'
 
 SequenceLocation:
   - name: "SequenceLocation w/ SequenceReference"
@@ -18,9 +18,9 @@ SequenceLocation:
         refgetAccession: SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul
       type: SequenceLocation
     out:
-      ga4gh_digest: BJTCCXVRY_ZGRADPZfwI7bGj21BQgR3w
-      ga4gh_identify: ga4gh:SL.BJTCCXVRY_ZGRADPZfwI7bGj21BQgR3w
-      ga4gh_serialize: '{"end":44908822,"sequenceReference":{"refgetAccession":"SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"},"start":44908821,"type":"SequenceLocation"}'
+      ga4gh_digest: 4t6JnYWqHwYw9WzBT_lmWBb3tLQNalkT
+      ga4gh_identify: ga4gh:SL.4t6JnYWqHwYw9WzBT_lmWBb3tLQNalkT
+      ga4gh_serialize: '{"end":44908822,"sequenceReference":{"refgetAccession":"SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul","type":"SequenceReference"},"start":44908821,"type":"SequenceLocation"}'
   - name: "SequenceLocation w/ SequenceReference and Ranges"
     in:
       end: [44908822,44908922]
@@ -31,9 +31,9 @@ SequenceLocation:
         refgetAccession: SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul
       type: SequenceLocation
     out:
-      ga4gh_digest: VxJI-XEX4fadRGGREWqMQ2-MxXfJIEW4
-      ga4gh_identify: ga4gh:SL.VxJI-XEX4fadRGGREWqMQ2-MxXfJIEW4
-      ga4gh_serialize: '{"end":[44908822,44908922],"sequenceReference":{"refgetAccession":"SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"},"start":[44908721,44908821],"type":"SequenceLocation"}'
+      ga4gh_digest: 8-sGv9AY7GJT6QVgqbxhMXFNamnWcFJu
+      ga4gh_identify: ga4gh:SL.8-sGv9AY7GJT6QVgqbxhMXFNamnWcFJu
+      ga4gh_serialize: '{"end":[44908822,44908922],"sequenceReference":{"refgetAccession":"SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul","type":"SequenceReference"},"start":[44908721,44908821],"type":"SequenceLocation"}'
   - name: "SequenceLocation w/Definite and Indefinite Ranges"
     in:
       end: [44908822,null]
@@ -43,9 +43,9 @@ SequenceLocation:
         refgetAccession: SQ.jdEWLvLvT8827O59m1Agh5H3n6kTzBsJ
       type: SequenceLocation
     out:
-      ga4gh_digest: 55fM_fsoXOQL3AzfCL5XLX26JsoOpgMC
-      ga4gh_identify: ga4gh:SL.55fM_fsoXOQL3AzfCL5XLX26JsoOpgMC
-      ga4gh_serialize: '{"end":[44908822,null],"sequenceReference":{"refgetAccession":"SQ.jdEWLvLvT8827O59m1Agh5H3n6kTzBsJ"},"start":[44908721,44908821],"type":"SequenceLocation"}'
+      ga4gh_digest: CyBy1ACd1JO3erBh3TG2ZE4zHe0LFhdL
+      ga4gh_identify: ga4gh:SL.CyBy1ACd1JO3erBh3TG2ZE4zHe0LFhdL
+      ga4gh_serialize: '{"end":[44908822,null],"sequenceReference":{"refgetAccession":"SQ.jdEWLvLvT8827O59m1Agh5H3n6kTzBsJ","type":"SequenceReference"},"start":[44908721,44908821],"type":"SequenceLocation"}'
   - name: "SequenceLocation w/more Definite and Indefinite Ranges"
     in:
       end: [null,44908822]
@@ -55,9 +55,9 @@ SequenceLocation:
         refgetAccession: SQ.jdEWLvLvT8827O59m1Agh5H3n6kTzBsJ
       type: SequenceLocation
     out:
-      ga4gh_digest: ypissgRitP7FIBq--kxJq-XHg8L7K09_
-      ga4gh_identify: ga4gh:SL.ypissgRitP7FIBq--kxJq-XHg8L7K09_
-      ga4gh_serialize: '{"end":[null,44908822],"sequenceReference":{"refgetAccession":"SQ.jdEWLvLvT8827O59m1Agh5H3n6kTzBsJ"},"start":[44908721,44908821],"type":"SequenceLocation"}'
+      ga4gh_digest: eKeAwwmhtcMK_qdvcsw8xERJWC5IEPB1
+      ga4gh_identify: ga4gh:SL.eKeAwwmhtcMK_qdvcsw8xERJWC5IEPB1
+      ga4gh_serialize: '{"end":[null,44908822],"sequenceReference":{"refgetAccession":"SQ.jdEWLvLvT8827O59m1Agh5H3n6kTzBsJ","type":"SequenceReference"},"start":[44908721,44908821],"type":"SequenceLocation"}'
 
 LiteralSequenceExpression:
   -
@@ -96,9 +96,9 @@ Allele:
         type: LiteralSequenceExpression
       type: Allele
     out:
-      ga4gh_digest: Yej0kQTGuatF6tXLAarhWzzHqC6VupfN
-      ga4gh_identify: ga4gh:VA.Yej0kQTGuatF6tXLAarhWzzHqC6VupfN
-      ga4gh_serialize: '{"location":"SV29i6tMRls5ptHzSc6klvB_dBBm_9_2","state":{"sequence":"T","type":"LiteralSequenceExpression"},"type":"Allele"}'
+      ga4gh_digest: NRUtY5Jcoevxr0tIgbNa-oIFm-Gv4qas
+      ga4gh_identify: ga4gh:VA.NRUtY5Jcoevxr0tIgbNa-oIFm-Gv4qas
+      ga4gh_serialize: '{"location":"DLRL0aHPUV-AS7_bgdWlQUdGT7aD_ys8","state":{"sequence":"T","type":"LiteralSequenceExpression"},"type":"Allele"}'
   - name: "NC_000001.11:40819438:CTCCTCCT:CTCCTCCTCCT w/ReferenceLengthExpression"
     in:
       type: Allele
@@ -118,9 +118,9 @@ Allele:
         length: 11
         repeatSubunitLength: 3
     out:
-      ga4gh_digest: bPzvmRkN82_-1D2JCl_ci2GVe2vbLVoL
-      ga4gh_identify: ga4gh:VA.bPzvmRkN82_-1D2JCl_ci2GVe2vbLVoL
-      ga4gh_serialize: '{"location":"n_PaG3rJyo78uxAm2mhPZ0QOCkdxRKLc","state":{"length":11,"repeatSubunitLength":3,"type":"ReferenceLengthExpression"},"type":"Allele"}'
+      ga4gh_digest: Oop4kjdTtKcg1kiZjIJAAR3bp7qi4aNT
+      ga4gh_identify: ga4gh:VA.Oop4kjdTtKcg1kiZjIJAAR3bp7qi4aNT
+      ga4gh_serialize: '{"location":"nQGBuvRQOLEboA5TYtcz975fp_GulxbZ","state":{"length":11,"repeatSubunitLength":3,"type":"ReferenceLengthExpression"},"type":"Allele"}'
 
 CisPhasedBlock:
   - name: "APOE1 on GRCh38, inline"
@@ -150,9 +150,9 @@ CisPhasedBlock:
         type: Allele
       type: CisPhasedBlock
     out:
-      ga4gh_digest: KDwfvAoLSVyNOfbsGhN7UjvQJExm03Lt
-      ga4gh_identify: ga4gh:CPB.KDwfvAoLSVyNOfbsGhN7UjvQJExm03Lt
-      ga4gh_serialize: '{"members":["JhBaSrFZs1oi79WPHW1tREtwOtT0hG9V","PQCvUrADPw5nT6XaWXHym55K8do18-NC"],"type":"CisPhasedBlock"}'
+      ga4gh_digest: pS8ubMBiWe0SIAotItLTT0bV3wxycLCj
+      ga4gh_identify: ga4gh:CPB.pS8ubMBiWe0SIAotItLTT0bV3wxycLCj
+      ga4gh_serialize: '{"members":["CvJUnTllC5zQ-M1Hbj9oj6BQitKw67J9","QZGrlXd07EPr1mUVyhfaEN8mJVmN1PGF"],"type":"CisPhasedBlock"}'
   - name: "APOE1 on GRCh38, referenced"
     in:
       members:
@@ -177,9 +177,9 @@ CopyNumberCount:
         type: SequenceLocation
       type: CopyNumberCount
     out:
-      ga4gh_digest: 9-sXqmmLm_tU1rftf8WVs6ooEA8Nn8kb
-      ga4gh_identify: ga4gh:CN.9-sXqmmLm_tU1rftf8WVs6ooEA8Nn8kb
-      ga4gh_serialize: '{"copies":[3,null],"location":"nxJNH6lXYCfpXQMESj6xxMhLbHOjBWPi","type":"CopyNumberCount"}'
+      ga4gh_digest: ezEUXykQvIhX8jHADILwC9f8k-jp8tZC
+      ga4gh_identify: ga4gh:CN.ezEUXykQvIhX8jHADILwC9f8k-jp8tZC
+      ga4gh_serialize: '{"copies":[3,null],"location":"d9h3FkfTWFkJSH56L1A26y-N2oq_SSuB","type":"CopyNumberCount"}'
 
 CopyNumberChange:
   - name: "Low-level copy gain of BRCA1"
@@ -194,6 +194,6 @@ CopyNumberChange:
         type: SequenceLocation
       type: CopyNumberChange
     out:
-      ga4gh_digest: oYOQt_Vwa8cagOKELBY1Umrl7KsjUef5
-      ga4gh_identify: ga4gh:CX.oYOQt_Vwa8cagOKELBY1Umrl7KsjUef5
-      ga4gh_serialize: '{"copyChange":"efo:0030071","location":"nxJNH6lXYCfpXQMESj6xxMhLbHOjBWPi","type":"CopyNumberChange"}'
+      ga4gh_digest: 4_sKBXNG9zYX62D-FR2K-hUp1la-eaYc
+      ga4gh_identify: ga4gh:CX.4_sKBXNG9zYX62D-FR2K-hUp1la-eaYc
+      ga4gh_serialize: '{"copyChange":"efo:0030071","location":"d9h3FkfTWFkJSH56L1A26y-N2oq_SSuB","type":"CopyNumberChange"}'


### PR DESCRIPTION
Resolve issue in #479

* Updates description for Value Object wrt serialization / digests
* Add missing `type` to `ga4ghDigest.keys`