### PR TITLE
fix!: efo -> EFO

### DIFF
--- a/schema/vrs/def/CopyNumberChange.rst
+++ b/schema/vrs/def/CopyNumberChange.rst
@@ -3,7 +3,7 @@
 An assessment of the copy number of a :ref:`Location` or a :ref:`Gene` within a system (e.g. genome, cell, etc.) relative to a baseline ploidy.
 
     **Information Model**
-    
+
 Some CopyNumberChange attributes are inherited from :ref:`CopyNumber`.
 
     .. list-table::
@@ -11,7 +11,7 @@ Some CopyNumberChange attributes are inherited from :ref:`CopyNumber`.
        :header-rows: 1
        :align: left
        :widths: auto
-       
+
        *  - Field
           - Type
           - Limits
@@ -47,7 +47,7 @@ Some CopyNumberChange attributes are inherited from :ref:`CopyNumber`.
        *  - expressions
           - `Expression <../gks-common/common.json#/$defs/Expression>`_
           - 0..m
-          - 
+          -
        *  - location
           - `IRI <../gks-common/common.json#/$defs/IRI>`_ | :ref:`Location`
           - 1..1
@@ -59,4 +59,4 @@ Some CopyNumberChange attributes are inherited from :ref:`CopyNumber`.
        *  - copyChange
           - string
           - 1..1
-          - MUST be one of "efo:0030069" (complete genomic loss), "efo:0020073" (high-level loss), "efo:0030068" (low-level loss), "efo:0030067" (loss), "efo:0030064" (regional base ploidy), "efo:0030070" (gain), "efo:0030071" (low-level gain), "efo:0030072" (high-level gain).
+          - MUST be one of "EFO:0030069" (complete genomic loss), "EFO:0020073" (high-level loss), "EFO:0030068" (low-level loss), "EFO:0030067" (loss), "EFO:0030064" (regional base ploidy), "EFO:0030070" (gain), "EFO:0030071" (low-level gain), "EFO:0030072" (high-level gain).

--- a/schema/vrs/json/CopyNumberChange
+++ b/schema/vrs/json/CopyNumberChange
@@ -82,16 +82,16 @@
       "copyChange": {
          "type": "string",
          "enum": [
-            "efo:0030069",
-            "efo:0020073",
-            "efo:0030068",
-            "efo:0030067",
-            "efo:0030064",
-            "efo:0030070",
-            "efo:0030071",
-            "efo:0030072"
+            "EFO:0030069",
+            "EFO:0020073",
+            "EFO:0030068",
+            "EFO:0030067",
+            "EFO:0030064",
+            "EFO:0030070",
+            "EFO:0030071",
+            "EFO:0030072"
          ],
-         "description": "MUST be one of \"efo:0030069\" (complete genomic loss), \"efo:0020073\" (high-level loss), \"efo:0030068\" (low-level loss), \"efo:0030067\" (loss), \"efo:0030064\" (regional base ploidy), \"efo:0030070\" (gain), \"efo:0030071\" (low-level gain), \"efo:0030072\" (high-level gain)."
+         "description": "MUST be one of \"EFO:0030069\" (complete genomic loss), \"EFO:0020073\" (high-level loss), \"EFO:0030068\" (low-level loss), \"EFO:0030067\" (loss), \"EFO:0030064\" (regional base ploidy), \"EFO:0030070\" (gain), \"EFO:0030071\" (low-level gain), \"EFO:0030072\" (high-level gain)."
       }
    },
    "required": [

--- a/schema/vrs/vrs-source.yaml
+++ b/schema/vrs/vrs-source.yaml
@@ -231,12 +231,12 @@ $defs:
           MUST be "CopyNumberChange"
       copyChange:
         type: string
-        enum: [ "efo:0030069", "efo:0020073", "efo:0030068", "efo:0030067", "efo:0030064", "efo:0030070",
-                "efo:0030071", "efo:0030072" ]
+        enum: [ "EFO:0030069", "EFO:0020073", "EFO:0030068", "EFO:0030067", "EFO:0030064", "EFO:0030070",
+                "EFO:0030071", "EFO:0030072" ]
         description: >-
-          MUST be one of "efo:0030069" (complete genomic loss), "efo:0020073" (high-level loss),
-          "efo:0030068" (low-level loss), "efo:0030067" (loss), "efo:0030064" (regional base ploidy),
-          "efo:0030070" (gain), "efo:0030071" (low-level gain), "efo:0030072" (high-level gain).
+          MUST be one of "EFO:0030069" (complete genomic loss), "EFO:0020073" (high-level loss),
+          "EFO:0030068" (low-level loss), "EFO:0030067" (loss), "EFO:0030064" (regional base ploidy),
+          "EFO:0030070" (gain), "EFO:0030071" (low-level gain), "EFO:0030072" (high-level gain).
     required: [ "copyChange" ]
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -298,7 +298,7 @@ $defs:
     maturity: draft
     inherits: ValueObject
     ga4ghDigest:
-      keys: 
+      keys:
         - refgetAccession
         - type
     type: object
@@ -510,7 +510,7 @@ $defs:
         description: >-
           A flag indicating if coordinate ambiguity in the adjoined sequences is from sequence homology
           (true) or other uncertainty (false).
-    required: 
+    required:
       - adjoinedSequences
 
   SequenceTerminus:
@@ -536,7 +536,7 @@ $defs:
           - $refCurie: gks.common:IRI
           - $ref: '#/$defs/Location'
         description: The location of the terminus.
-    required: 
+    required:
       - location
 
   DerivativeSequence:
@@ -570,5 +570,5 @@ $defs:
         description: >-
           The sequence components that make up the derivative sequence.
         minItems: 2
-    required: 
+    required:
       - components

--- a/validation/models.yaml
+++ b/validation/models.yaml
@@ -359,7 +359,7 @@ CopyNumberCount:
 CopyNumberChange:
   - name: "Low-level copy gain of BRCA1"
     in:
-      copyChange: efo:0030071
+      copyChange: EFO:0030071
       location:
         sequenceReference:
           type: SequenceReference
@@ -369,6 +369,6 @@ CopyNumberChange:
         type: SequenceLocation
       type: CopyNumberChange
     out:
-      ga4gh_digest: 4_sKBXNG9zYX62D-FR2K-hUp1la-eaYc
-      ga4gh_identify: ga4gh:CX.4_sKBXNG9zYX62D-FR2K-hUp1la-eaYc
-      ga4gh_serialize: '{"copyChange":"efo:0030071","location":"d9h3FkfTWFkJSH56L1A26y-N2oq_SSuB","type":"CopyNumberChange"}'
+      ga4gh_digest: 2_fT_6-IpUm5aS0wp8ZAkJ01MCE569L2
+      ga4gh_identify: ga4gh:CX.2_fT_6-IpUm5aS0wp8ZAkJ01MCE569L2
+      ga4gh_serialize: '{"copyChange":"EFO:0030071","location":"d9h3FkfTWFkJSH56L1A26y-N2oq_SSuB","type":"CopyNumberChange"}'


### PR DESCRIPTION
* @cmungall pointed out the case difference in github.com/ga4gh/cat-vrs/issues/39
* copyChange now follows the convention preferred by EMBL-EBI as the EFO authority
* CopyNumberChange variation computed identifiers will change