### PR TITLE
docs: resolve typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ requests, release candidate discussions, and questions.
 ## Issues
 [Issues](https://github.com/ga4gh/vrs/issues) are for bug
 reports, and planned feature descriptions. When creating an issue, use 
-sentence casefor the issue title and avoid the use of periods at the end 
+sentence case for the issue title and avoid the use of periods at the end
 of titles.
 
 ## Branches

--- a/docs/source/appendices/class_diagram.rst
+++ b/docs/source/appendices/class_diagram.rst
@@ -4,11 +4,10 @@ Class Diagram
 !!!!!!!!!!!!!
 
 Below is a class diagram of the VRS schema which provides a visual representation
-of the class inheritance only not associations. Each class within the diagram is
+of the class inheritance only, not associations. Each class within the diagram is
 tagged with the maturity level of the class in the upper right corner. The maturity
 levels are defined in the :ref:`feature-maturity-levels` section.
 
 .. figure:: ../images/schema-current.png
 
    Current VRS Class Inheritance Diagram
-

--- a/docs/source/concepts/index.rst
+++ b/docs/source/concepts/index.rst
@@ -1,8 +1,8 @@
 Concepts
 !!!!!!!!
 
-VRS is a collection of data models or concepts that are used together to represent molecular 
-and systemic variation. An inhertiance view is available in the :ref:`ClassDiagram` appendix.
+VRS is a collection of data models or concepts that are used together to represent molecular
+and systemic variation. An inheritance view is available in the :ref:`ClassDiagram` appendix.
 These models exist across several related domains:
 
 - :ref:`MolecularVariation`: models that describe variation on a contiguous molecule


### PR DESCRIPTION
I've been looking at the RTD (which is great to see all the work in one place) and noticed some minor typos. 