### PR TITLE
feat: add beacon syntax

### DIFF
--- a/schema/vrs/def/Expression.rst
+++ b/schema/vrs/def/Expression.rst
@@ -38,7 +38,7 @@ Some Expression attributes are inherited from :ref:`gks-core:Element`.
       -
       - string
       - 1..1
-      - The syntax used to describe the variation. The value should be one of the supported syntaxes.
+      - The syntax used to describe the variation. The value MUST be one of the supported syntaxes.
    *  - value
       -
       - string

--- a/schema/vrs/json/Expression
+++ b/schema/vrs/json/Expression
@@ -33,7 +33,7 @@
             "spdi",
             "beacon"
          ],
-         "description": "The syntax used to describe the variation. The value should be one of the supported syntaxes."
+         "description": "The syntax used to describe the variation. The value MUST be one of the supported syntaxes."
       },
       "value": {
          "type": "string",

--- a/schema/vrs/json/Expression
+++ b/schema/vrs/json/Expression
@@ -30,7 +30,8 @@
             "hgvs.r",
             "iscn",
             "gnomad",
-            "spdi"
+            "spdi",
+            "beacon"
          ],
          "description": "The syntax used to describe the variation. The value should be one of the supported syntaxes."
       },

--- a/schema/vrs/vrs-source.yaml
+++ b/schema/vrs/vrs-source.yaml
@@ -76,7 +76,7 @@ $defs:
         type: string
         enum: ["hgvs.c", "hgvs.p", "hgvs.g", "hgvs.m", "hgvs.n", "hgvs.r", "iscn", "gnomad", "spdi", "beacon"]
         description: >-
-          The syntax used to describe the variation. The value should be one of the supported syntaxes.
+          The syntax used to describe the variation. The value MUST be one of the supported syntaxes.
       value:
         type: string
         description: >-

--- a/schema/vrs/vrs-source.yaml
+++ b/schema/vrs/vrs-source.yaml
@@ -74,7 +74,7 @@ $defs:
     properties:
       syntax:
         type: string
-        enum: ["hgvs.c", "hgvs.p", "hgvs.g", "hgvs.m", "hgvs.n", "hgvs.r", "iscn", "gnomad", "spdi"]
+        enum: ["hgvs.c", "hgvs.p", "hgvs.g", "hgvs.m", "hgvs.n", "hgvs.r", "iscn", "gnomad", "spdi", "beacon"]
         description: >-
           The syntax used to describe the variation. The value should be one of the supported syntaxes.
       value:


### PR DESCRIPTION
(low priority)

Following up from https://github.com/ga4gh/vrs-python/issues/478#issuecomment-2666896871. It seems like either VRS should support this Beacon syntax style, or VRS-Python shouldn't translate from Beacon.

also -- use of "should" in the description seems incorrect for an enum. I can revert that change if it's intentional though.