### PR TITLE
Update gks core 2025 02.3

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,6 +40,9 @@ master_doc = 'index'
 # N.B. RTD ignores these values. :-/
 release = _get_git_tag()
 version = _parse_release_as_version(release)
+# Automatically use the RTD branch/tag as the GitHub version
+github_version = os.environ.get("READTHEDOCS_VERSION", "main")
+
 
 # -- Schema doc paths --------------------------------------------------------
 
@@ -82,7 +85,11 @@ html_theme_options = {
     'collapse_navigation': False
 }
 html_context = {
-    "display_github": True
+    "conf_py_path": "/docs/source/",
+    "display_github": True,
+    "github_user": "ga4gh",
+    "github_repo": "vrs",
+    "github_version": github_version,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/schema/vrs/json/Adjacency
+++ b/schema/vrs/json/Adjacency
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Adjacency",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Adjacency",
    "title": "Adjacency",
    "type": "object",
    "maturity": "trial use",
@@ -53,7 +53,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Expression"
+            "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Expression"
          }
       },
       "type": {
@@ -69,7 +69,7 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceLocation"
+                  "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/SequenceLocation"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"
@@ -90,13 +90,13 @@
          "description": "The sequence found between adjoined sequences.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/LengthExpression"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/LengthExpression"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/LiteralSequenceExpression"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/LiteralSequenceExpression"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/ReferenceLengthExpression"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/ReferenceLengthExpression"
             }
          ]
       },

--- a/schema/vrs/json/Adjacency
+++ b/schema/vrs/json/Adjacency
@@ -39,7 +39,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -72,7 +72,7 @@
                   "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceLocation"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"
                }
             ],
             "not": {

--- a/schema/vrs/json/Allele
+++ b/schema/vrs/json/Allele
@@ -39,7 +39,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -68,7 +68,7 @@
                "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceLocation"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"
             }
          ],
          "description": "The location of the Allele"

--- a/schema/vrs/json/Allele
+++ b/schema/vrs/json/Allele
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Allele",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Allele",
    "title": "Allele",
    "type": "object",
    "maturity": "trial use",
@@ -53,7 +53,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Expression"
+            "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Expression"
          }
       },
       "type": {
@@ -65,7 +65,7 @@
       "location": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceLocation"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/SequenceLocation"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"
@@ -77,13 +77,13 @@
          "description": "An expression of the sequence state",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/LengthExpression"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/LengthExpression"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/LiteralSequenceExpression"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/LiteralSequenceExpression"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/ReferenceLengthExpression"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/ReferenceLengthExpression"
             }
          ]
       }

--- a/schema/vrs/json/CisPhasedBlock
+++ b/schema/vrs/json/CisPhasedBlock
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/CisPhasedBlock",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/CisPhasedBlock",
    "title": "CisPhasedBlock",
    "type": "object",
    "maturity": "trial use",
@@ -52,7 +52,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Expression"
+            "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Expression"
          }
       },
       "type": {
@@ -69,7 +69,7 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Allele"
+                  "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Allele"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"
@@ -79,7 +79,7 @@
          "description": "A list of Alleles that are found in-cis on a shared molecule."
       },
       "sequenceReference": {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceReference",
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/SequenceReference",
          "description": "An optional Sequence Reference on which all of the in-cis Alleles are found. When defined, this may be used to implicitly define the `sequenceReference` attribute for each of the CisPhasedBlock member Alleles."
       }
    },

--- a/schema/vrs/json/CisPhasedBlock
+++ b/schema/vrs/json/CisPhasedBlock
@@ -38,7 +38,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -72,7 +72,7 @@
                   "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Allele"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"
                }
             ]
          },

--- a/schema/vrs/json/CopyNumberChange
+++ b/schema/vrs/json/CopyNumberChange
@@ -39,7 +39,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -68,14 +68,14 @@
                "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceLocation"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"
             }
          ],
          "description": "The location of the subject of the copy change."
       },
       "copyChange": {
          "description": "MUST use a `primaryCode` representing one of \"EFO:0030069\" (complete genomic loss), \"EFO:0020073\" (high-level loss), \"EFO:0030068\" (low-level loss), \"EFO:0030067\" (loss), \"EFO:0030064\" (regional base ploidy), \"EFO:0030070\" (gain), \"EFO:0030071\" (low-level gain), \"EFO:0030072\" (high-level gain).",
-         "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/MappableConcept"
       }
    },
    "required": [

--- a/schema/vrs/json/CopyNumberChange
+++ b/schema/vrs/json/CopyNumberChange
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/CopyNumberChange",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/CopyNumberChange",
    "title": "CopyNumberChange",
    "type": "object",
    "maturity": "draft",
@@ -53,7 +53,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Expression"
+            "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Expression"
          }
       },
       "type": {
@@ -65,7 +65,7 @@
       "location": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceLocation"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/SequenceLocation"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"

--- a/schema/vrs/json/CopyNumberCount
+++ b/schema/vrs/json/CopyNumberCount
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/CopyNumberCount",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/CopyNumberCount",
    "title": "CopyNumberCount",
    "type": "object",
    "maturity": "trial use",
@@ -53,7 +53,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Expression"
+            "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Expression"
          }
       },
       "type": {
@@ -65,7 +65,7 @@
       "location": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceLocation"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/SequenceLocation"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"
@@ -76,7 +76,7 @@
       "copies": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Range"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Range"
             },
             {
                "type": "integer"

--- a/schema/vrs/json/CopyNumberCount
+++ b/schema/vrs/json/CopyNumberCount
@@ -39,7 +39,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -68,7 +68,7 @@
                "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceLocation"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"
             }
          ],
          "description": "The location of the subject of the copy count."

--- a/schema/vrs/json/DerivativeMolecule
+++ b/schema/vrs/json/DerivativeMolecule
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/DerivativeMolecule",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/DerivativeMolecule",
    "title": "DerivativeMolecule",
    "type": "object",
    "maturity": "draft",
@@ -52,7 +52,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Expression"
+            "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Expression"
          }
       },
       "type": {
@@ -68,16 +68,16 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Allele"
+                  "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Allele"
                },
                {
-                  "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/CisPhasedBlock"
+                  "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/CisPhasedBlock"
                },
                {
-                  "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Terminus"
+                  "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Terminus"
                },
                {
-                  "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/TraversalBlock"
+                  "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/TraversalBlock"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"

--- a/schema/vrs/json/DerivativeMolecule
+++ b/schema/vrs/json/DerivativeMolecule
@@ -38,7 +38,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -80,7 +80,7 @@
                   "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/TraversalBlock"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"
                }
             ]
          },

--- a/schema/vrs/json/Expression
+++ b/schema/vrs/json/Expression
@@ -14,7 +14,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/vrs/json/Expression
+++ b/schema/vrs/json/Expression
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Expression",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Expression",
    "title": "Expression",
    "type": "object",
    "maturity": "trial use",

--- a/schema/vrs/json/LengthExpression
+++ b/schema/vrs/json/LengthExpression
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/LengthExpression",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/LengthExpression",
    "title": "LengthExpression",
    "type": "object",
    "maturity": "draft",
@@ -53,7 +53,7 @@
          "description": "The length of the sequence.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Range"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Range"
             },
             {
                "type": "integer"

--- a/schema/vrs/json/LengthExpression
+++ b/schema/vrs/json/LengthExpression
@@ -37,7 +37,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/vrs/json/LiteralSequenceExpression
+++ b/schema/vrs/json/LiteralSequenceExpression
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/LiteralSequenceExpression",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/LiteralSequenceExpression",
    "title": "LiteralSequenceExpression",
    "type": "object",
    "maturity": "trial use",
@@ -50,7 +50,7 @@
          "default": "LiteralSequenceExpression"
       },
       "sequence": {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/sequenceString",
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/sequenceString",
          "description": "the literal sequence"
       }
    },

--- a/schema/vrs/json/LiteralSequenceExpression
+++ b/schema/vrs/json/LiteralSequenceExpression
@@ -37,7 +37,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/vrs/json/Location
+++ b/schema/vrs/json/Location
@@ -1,13 +1,13 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Location",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Location",
    "title": "Location",
    "type": "object",
    "maturity": "trial use",
    "description": "A contiguous segment of a biological sequence.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceLocation"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/SequenceLocation"
       }
    ],
    "discriminator": {

--- a/schema/vrs/json/MolecularVariation
+++ b/schema/vrs/json/MolecularVariation
@@ -1,25 +1,25 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/MolecularVariation",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/MolecularVariation",
    "title": "MolecularVariation",
    "type": "object",
    "maturity": "trial use",
    "description": "A variation on a contiguous molecule.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Adjacency"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Adjacency"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Allele"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Allele"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/CisPhasedBlock"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/CisPhasedBlock"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/DerivativeMolecule"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/DerivativeMolecule"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Terminus"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Terminus"
       }
    ],
    "discriminator": {

--- a/schema/vrs/json/Range
+++ b/schema/vrs/json/Range
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Range",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Range",
    "title": "Range",
    "type": "array",
    "maturity": "trial use",

--- a/schema/vrs/json/ReferenceLengthExpression
+++ b/schema/vrs/json/ReferenceLengthExpression
@@ -38,7 +38,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/vrs/json/ReferenceLengthExpression
+++ b/schema/vrs/json/ReferenceLengthExpression
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/ReferenceLengthExpression",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/ReferenceLengthExpression",
    "title": "ReferenceLengthExpression",
    "type": "object",
    "maturity": "trial use",
@@ -53,7 +53,7 @@
       "length": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Range"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Range"
             },
             {
                "type": "integer"
@@ -62,7 +62,7 @@
          "description": "The number of residues in the expressed sequence."
       },
       "sequence": {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/sequenceString",
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/sequenceString",
          "description": "the literal Sequence encoded by the Reference Length Expression."
       },
       "repeatSubunitLength": {

--- a/schema/vrs/json/SequenceExpression
+++ b/schema/vrs/json/SequenceExpression
@@ -1,19 +1,19 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceExpression",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/SequenceExpression",
    "title": "SequenceExpression",
    "type": "object",
    "maturity": "trial use",
    "description": "An expression describing a Sequence.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/LengthExpression"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/LengthExpression"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/LiteralSequenceExpression"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/LiteralSequenceExpression"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/ReferenceLengthExpression"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/ReferenceLengthExpression"
       }
    ],
    "discriminator": {

--- a/schema/vrs/json/SequenceLocation
+++ b/schema/vrs/json/SequenceLocation
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceLocation",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/SequenceLocation",
    "title": "SequenceLocation",
    "type": "object",
    "maturity": "trial use",
@@ -59,7 +59,7 @@
       "sequenceReference": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceReference"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/SequenceReference"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"
@@ -70,7 +70,7 @@
       "start": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Range"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Range"
             },
             {
                "type": "integer"
@@ -81,7 +81,7 @@
       "end": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Range"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Range"
             },
             {
                "type": "integer"
@@ -91,7 +91,7 @@
       },
       "sequence": {
          "description": "The literal sequence encoded by the `sequenceReference` at these coordinates.",
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/sequenceString"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/sequenceString"
       }
    },
    "required": [

--- a/schema/vrs/json/SequenceLocation
+++ b/schema/vrs/json/SequenceLocation
@@ -40,7 +40,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -62,7 +62,7 @@
                "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceReference"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"
             }
          ],
          "description": "A reference to a SequenceReference on which the location is defined."

--- a/schema/vrs/json/SequenceReference
+++ b/schema/vrs/json/SequenceReference
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceReference",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/SequenceReference",
    "title": "SequenceReference",
    "type": "object",
    "maturity": "trial use",
@@ -63,7 +63,7 @@
          ]
       },
       "sequence": {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/sequenceString",
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/sequenceString",
          "description": "A sequenceString that is a literal representation of the referenced sequence."
       },
       "moleculeType": {

--- a/schema/vrs/json/SequenceReference
+++ b/schema/vrs/json/SequenceReference
@@ -37,7 +37,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/vrs/json/SystemicVariation
+++ b/schema/vrs/json/SystemicVariation
@@ -1,16 +1,16 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SystemicVariation",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/SystemicVariation",
    "title": "SystemicVariation",
    "type": "object",
    "maturity": "trial use",
    "description": "A Variation of multiple molecules in the context of a system, e.g. a genome, sample, or homologous chromosomes.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/CopyNumberChange"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/CopyNumberChange"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/CopyNumberCount"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/CopyNumberCount"
       }
    ],
    "discriminator": {

--- a/schema/vrs/json/Terminus
+++ b/schema/vrs/json/Terminus
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Terminus",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Terminus",
    "title": "Terminus",
    "type": "object",
    "maturity": "draft",
@@ -52,7 +52,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Expression"
+            "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Expression"
          }
       },
       "type": {
@@ -64,7 +64,7 @@
       "location": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceLocation"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/SequenceLocation"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"

--- a/schema/vrs/json/Terminus
+++ b/schema/vrs/json/Terminus
@@ -38,7 +38,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -67,7 +67,7 @@
                "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/SequenceLocation"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/iriReference"
             }
          ],
          "description": "The location of the terminus."

--- a/schema/vrs/json/TraversalBlock
+++ b/schema/vrs/json/TraversalBlock
@@ -38,7 +38,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/vrs/json/TraversalBlock
+++ b/schema/vrs/json/TraversalBlock
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/TraversalBlock",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/TraversalBlock",
    "title": "TraversalBlock",
    "type": "object",
    "maturity": "draft",
@@ -54,7 +54,7 @@
          "description": "The unoriented molecular variation component.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Adjacency"
+               "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Adjacency"
             }
          ]
       },

--- a/schema/vrs/json/Variation
+++ b/schema/vrs/json/Variation
@@ -1,31 +1,31 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Variation",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Variation",
    "title": "Variation",
    "type": "object",
    "maturity": "trial use",
    "description": "A representation of the state of one or more biomolecules.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Adjacency"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Adjacency"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Allele"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Allele"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/CisPhasedBlock"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/CisPhasedBlock"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/CopyNumberChange"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/CopyNumberChange"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/CopyNumberCount"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/CopyNumberCount"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/DerivativeMolecule"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/DerivativeMolecule"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/Terminus"
+         "$ref": "/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/Terminus"
       }
    ],
    "discriminator": {

--- a/schema/vrs/json/residue
+++ b/schema/vrs/json/residue
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/residue",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/residue",
    "title": "residue",
    "type": "string",
    "maturity": "trial use",

--- a/schema/vrs/json/sequenceString
+++ b/schema/vrs/json/sequenceString
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/json/sequenceString",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/json/sequenceString",
    "title": "sequenceString",
    "type": "string",
    "maturity": "trial use",

--- a/schema/vrs/vrs-source.yaml
+++ b/schema/vrs/vrs-source.yaml
@@ -9,7 +9,7 @@
 
 # https://json-schema.org/understanding-json-schema/reference/schema.html
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.2/vrs-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/vrs/2.0.0-snapshot.2025-02.3/vrs-source.yaml"
 title: "GA4GH-VRS-Definitions"
 type: object
 strict: true
@@ -18,7 +18,7 @@ imports:
   gks-core: ../gks-core/gks-core-source.yaml
 
 namespaces:
-  gks.core: /ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/
+  gks.core: /ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.3/json/
 
 $defs:
   # VRS definitions are presented top-down.  Everything rolls up to


### PR DESCRIPTION
- prep for new v3 of 2025-02 snapshot release 
- apply gks-core v3 2025-02 snapshot release with update to MappableConcept (primaryCoding and iris)
- add back the "Edit in Github" link to the RTDs output