### PR TITLE
docs: exclude `def` pages from search

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,7 +61,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+exclude_patterns = ["def"]
 
 # TODO directive output
 todo_include_todos = True


### PR DESCRIPTION
If you search for a term like "Identifier", the results include both the pages meant to be included in the Sphinx `toctree` as well as the orphan `def` pages which are embedded within them (these are the <no title> entries at the bottom):

![Screenshot 2025-03-18 at 12 16 32 PM](https://github.com/user-attachments/assets/bebf44d5-3cd4-4da0-b12e-23d3d463dff1)

Adding `def` to `exclude_patterns` in the configs prevents them from showing up in search.

* There are, like, a lot of broken `:ref:`s, btw (they shouldn't show up on the client side but if they're not meant to live on, it might be good to remove them)