### PR TITLE
docs: remove broken refs in releases

### DIFF
--- a/docs/source/releases/1.1.rst
+++ b/docs/source/releases/1.1.rst
@@ -49,9 +49,9 @@ Other data model changes
 Documentation changes
 #####################
 
-  * Added :ref:`relationships` to describe how VRS relates to other
+  * Added relationships to describe how VRS relates to other
     standards.
   * Updated :ref:`normalization` to clarify handling of reference
     alleles and generalize terminology to apply to all VRS objects.
   * Updated current and future schema diagrams.
-  * Included a discussion of the :ref:`release-cycle`.
+  * Included a discussion of the release-cycle.

--- a/docs/source/releases/1.2.rst
+++ b/docs/source/releases/1.2.rst
@@ -17,8 +17,7 @@ News
 Important
 #########
 
-  * :ref:`SimpleInterval and SequenceState are deprecated
-    <deprecations>`. They will be removed in VRS 2.0.
+  * SimpleInterval and SequenceState are deprecated. They will be removed in VRS 2.0.
 
 Major Changes
 #############
@@ -29,26 +28,26 @@ Major Changes
       contiguous molecule
     * :ref:`SystemicVariation` refers to variation in the context of a
       system, such as a genome, sample, or homologous chromosomes
-    * :ref:`UtilityVariation` classes provide useful representations
+    * UtilityVariation classes provide useful representations
       for certain technical operations
 
   * New :ref:`SequenceExpressions <SequenceExpression>` subclasses
     replace SequenceState. Subtypes are:
 
-    * :ref:`DerivedSequenceExpression`, which representations sequence
+    * DerivedSequenceExpression, which representations sequence
       notionally derived from a SequenceLocation
-    * :ref:`RepeatedSequenceExpression`, which represents contiguous
+    * RepeatedSequenceExpression, which represents contiguous
       repeats of a sequence
     * :ref:`LiteralSequenceExpression`, which
-      wraps a :ref:`Sequence` and provides data structure parity with
+      wraps a Sequence and provides data structure parity with
       other SequenceExpressions
-  * :ref:`CopyNumber`, a form of SystemicVariation, represents the
+  * CopyNumber, a form of SystemicVariation, represents the
     copies of a molecule within a genome, and can be used to express
     concepts such as amplification and copy loss.
-  * :ref:`Gene` enables reference to an external definition of a gene,
+  * Gene enables reference to an external definition of a gene,
     particularly for use as a subject of copy number expressions.
-  * :ref:`DefiniteRange` and :ref:`IndefiniteRange` represent bounded
-    and half-bounded ranges respectively. A new :ref:`Number` type
+  * DefiniteRange and IndefiniteRange represent bounded
+    and half-bounded ranges respectively. A new Number type
     wraps integers so that some attributes may assume values of any of
     these three types.
 
@@ -56,6 +55,6 @@ Major Changes
 Minor Changes
 #############
 
-  * Sequence strings are now formally defined by a :ref:`Sequence`
+  * Sequence strings are now formally defined by a Sequence
     type, which is fundamentally also a string. This change aids
     documentation but has no technical impact.

--- a/docs/source/releases/1.3.rst
+++ b/docs/source/releases/1.3.rst
@@ -8,7 +8,7 @@
 News
 ####
 
-  * A manuscript describing :ref:`Genotype` was published. Please cite
+  * A manuscript describing Genotype was published. Please cite
     https://www.worldscientific.com/doi/abs/10.1142/9789811270611_0035.
 
 Major Changes
@@ -16,15 +16,14 @@ Major Changes
 
   * :ref:`CopyNumberChange` introduced for relative copy number calls
   * :ref:`CopyNumberCount` replaces `CopyNumber (v1.2) <https://vrs.ga4gh.org/en/1.2.1/terms_and_model.html#copynumber>`_
-  * :ref:`Genotype` introduced as a new systemic variation concept
-  * :ref:`ComposedSequenceExpression` introduced for composing expressions from multiple other sequence expressions
+  * Genotype introduced as a new systemic variation concept
+  * ComposedSequenceExpression introduced for composing expressions from multiple other sequence expressions
 
 Minor Changes
 #############
 
-  * Clarifying updates for :ref:`Allele normalization guidance
-    <should-normalize>`
-  * :ref:`Haplotype` allele member minimum was revised from 1 to 2
+  * Clarifying updates for Allele normalization guidance
+  * Haplotype allele member minimum was revised from 1 to 2
   * Updated metaschema processor version
   * Introduced ordered / unordered attribute in array declarations
   * Added explicit class inheritance


### PR DESCRIPTION
* removes broken `:ref:` instances in old release pages on the docs.

I might recommend fewer/no internal references in the RTD changelogs moving forward. These are difficult/annoying to maintain. Alternatively, maybe wiping all refs in major releases?
