### PR TITLE
chore: bump gks-core from 1.0.0 to 1.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "submodules/gks-core"]
 	path = submodules/gks-core
 	url = https://github.com/ga4gh/gks-core.git
-	branch = 1.0
+	branch = 1.1

--- a/schema/vrs/json/Adjacency
+++ b/schema/vrs/json/Adjacency
@@ -39,7 +39,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -72,7 +72,7 @@
                   "$ref": "/ga4gh/schema/vrs/2.0.1/json/SequenceLocation"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
                }
             ],
             "not": {

--- a/schema/vrs/json/Allele
+++ b/schema/vrs/json/Allele
@@ -39,7 +39,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -68,7 +68,7 @@
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/SequenceLocation"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ],
          "description": "The location of the Allele"

--- a/schema/vrs/json/CisPhasedBlock
+++ b/schema/vrs/json/CisPhasedBlock
@@ -38,7 +38,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -72,7 +72,7 @@
                   "$ref": "/ga4gh/schema/vrs/2.0.1/json/Allele"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
                }
             ]
          },

--- a/schema/vrs/json/CopyNumberChange
+++ b/schema/vrs/json/CopyNumberChange
@@ -39,7 +39,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -68,7 +68,7 @@
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/SequenceLocation"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ],
          "description": "The location of the subject of the copy change."

--- a/schema/vrs/json/CopyNumberCount
+++ b/schema/vrs/json/CopyNumberCount
@@ -39,7 +39,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -68,7 +68,7 @@
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/SequenceLocation"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ],
          "description": "The location of the subject of the copy count."

--- a/schema/vrs/json/DerivativeMolecule
+++ b/schema/vrs/json/DerivativeMolecule
@@ -38,7 +38,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -80,7 +80,7 @@
                   "$ref": "/ga4gh/schema/vrs/2.0.1/json/TraversalBlock"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
                }
             ]
          },

--- a/schema/vrs/json/Expression
+++ b/schema/vrs/json/Expression
@@ -14,7 +14,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/vrs/json/LengthExpression
+++ b/schema/vrs/json/LengthExpression
@@ -37,7 +37,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/vrs/json/LiteralSequenceExpression
+++ b/schema/vrs/json/LiteralSequenceExpression
@@ -37,7 +37,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/vrs/json/ReferenceLengthExpression
+++ b/schema/vrs/json/ReferenceLengthExpression
@@ -38,7 +38,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/vrs/json/SequenceLocation
+++ b/schema/vrs/json/SequenceLocation
@@ -40,7 +40,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -62,7 +62,7 @@
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/SequenceReference"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ],
          "description": "A reference to a SequenceReference on which the location is defined."

--- a/schema/vrs/json/SequenceReference
+++ b/schema/vrs/json/SequenceReference
@@ -37,7 +37,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/vrs/json/Terminus
+++ b/schema/vrs/json/Terminus
@@ -38,7 +38,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -67,7 +67,7 @@
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/SequenceLocation"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ],
          "description": "The location of the terminus."

--- a/schema/vrs/json/TraversalBlock
+++ b/schema/vrs/json/TraversalBlock
@@ -38,7 +38,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/vrs/vrs-source.yaml
+++ b/schema/vrs/vrs-source.yaml
@@ -18,7 +18,7 @@ imports:
   gks-core: ../gks-core/gks-core-source.yaml
 
 namespaces:
-  gks.core: /ga4gh/schema/gks-core/1.0.0/json/
+  gks.core: /ga4gh/schema/gks-core/1.1.0/json/
 
 $defs:
   # VRS definitions are presented top-down.  Everything rolls up to


### PR DESCRIPTION
Once this is merged, I will:

1. Cherry-pick this commit into branch `2.0` (not sure if I have permissions to force push, so will prob have to create a new PR)
2. Create a VRS 2.0.2 release (which will create the VRS 2.0.2 tag)