### PR TITLE
docs: fix broken refs, remove unused sections

### DIFF
--- a/docs/source/appendices/design_decisions.rst
+++ b/docs/source/appendices/design_decisions.rst
@@ -91,6 +91,34 @@ the following syntax:
 
   https://w3id.org/ga4gh/vrs/VA.Oop4kjdTtKcg1kiZjIJAAR3bp7qi4aNT
 
+.. _inter-residue-coordinates-design:
+
+Inter-residue Coordinates
+@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+Sequence ranges use an inter-residue coordinate system. Inter-residue
+coordinate conventions are used in this terminology because they
+provide conceptual consistency that is not possible with residue-based
+systems.
+
+.. important:: The choice of what to count — residue or inter-residue
+               positions — has significant semantic implications for
+               the interpretation of coordinates.  Although
+               inter-residue coordinates and the "0-based" residue
+               coordinates are often numerically identical, we favor
+               "inter-residue" to emphasize the meaning of these
+               coordinates.
+
+When humans refer to a range of residues within a sequence, the most
+common convention is to use an interval of ordinal residue positions
+in the sequence. While natural for humans, this convention has several
+shortcomings when dealing with sequence variation.
+
+For example, interval coordinates are interpreted as exclusive
+coordinates for insertions, but as inclusive coordinates for
+substitutions and deletions; in effect, the interpretation of
+coordinates depends on the variant type, which is an unfortunate
+coupling of distinct concepts.
 Use of value sets for VRS computed digests
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 

--- a/docs/source/appendices/maturity_model.rst
+++ b/docs/source/appendices/maturity_model.rst
@@ -75,7 +75,7 @@ or may emerge in the course of technical specification development. It is expect
 that the need for product features are first discussed in a community forum (e.g.
 GitHub Discussions, GKS Work Stream calls).
 
-**Process**: Follow the GKS :ref:`development-process`. As part of this process,
+**Process**: Follow the GKS development process. As part of this process,
 it is expected that consensus among the decision-makers was reached and major design
 decisions documented. Disagreements are resolved per Work Stream and GA4GH processes.
 

--- a/docs/source/concepts/SequenceExpression/LiteralSequenceExpression.rst
+++ b/docs/source/concepts/SequenceExpression/LiteralSequenceExpression.rst
@@ -3,7 +3,7 @@
 Literal Sequence Expression
 !!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-A literal sequence expression is a literal representation of a :ref:`Sequence`.
+A literal sequence expression is a literal representation of a :ref:`sequence <sequenceString>`.
 
 Definition and Information Model
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,16 +16,22 @@ import subprocess
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+
 def _get_git_tag():
-    res = subprocess.run("git describe --tags --exact-match".split(), capture_output=True)
+    res = subprocess.run(
+        "git describe --tags --exact-match".split(), capture_output=True
+    )
     if res.stderr.decode().startswith("fatal"):
         # if no exact tag, then get branch
-        res = subprocess.run("git rev-parse --abbrev-ref HEAD".split(), capture_output=True)
+        res = subprocess.run(
+            "git rev-parse --abbrev-ref HEAD".split(), capture_output=True
+        )
     tag = res.stdout.decode().strip()
     return tag
 
+
 def _parse_release_as_version(rls):
-    m = re.match("^(\d+\.\d+)", rls)
+    m = re.match(r"^(\d+\.\d+)", rls)
     if m:
         return m.group(1)
     return rls
@@ -33,10 +39,10 @@ def _parse_release_as_version(rls):
 
 # -- Project information -----------------------------------------------------
 
-project = 'GA4GH Variation Representation Specification'
-copyright = '2021, GA4GH VRS Contributors'
-author = 'Committers'
-master_doc = 'index'
+project = "GA4GH Variation Representation Specification"
+copyright = "2021, GA4GH VRS Contributors"
+author = "Committers"
+master_doc = "index"
 # N.B. RTD ignores these values. :-/
 release = _get_git_tag()
 version = _parse_release_as_version(release)
@@ -46,7 +52,7 @@ github_version = os.environ.get("READTHEDOCS_VERSION", "main")
 
 # -- Schema doc paths --------------------------------------------------------
 
-rst_epilog_fn = os.path.join(os.path.dirname(__file__), 'rst_epilog')
+rst_epilog_fn = os.path.join(os.path.dirname(__file__), "rst_epilog")
 rst_epilog = open(rst_epilog_fn).read().format(release=release)
 
 # -- General configuration ---------------------------------------------------
@@ -54,12 +60,10 @@ rst_epilog = open(rst_epilog_fn).read().format(release=release)
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    'sphinx.ext.todo'
-]
+extensions = ["sphinx.ext.todo"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -78,12 +82,10 @@ todo_emit_warnings = True
 # The theme to use for HTML and HTML Help pages. See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
-html_logo = 'images/GA-logo.png'
+html_theme = "sphinx_rtd_theme"
+html_logo = "images/GA-logo.png"
 
-html_theme_options = {
-    'collapse_navigation': False
-}
+html_theme_options = {"collapse_navigation": False}
 html_context = {
     "conf_py_path": "/docs/source/",
     "display_github": True,
@@ -95,11 +97,12 @@ html_context = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
-html_css_files = ['theme_overrides.css']
+html_css_files = ["theme_overrides.css"]
 
 # Sidebars
 
-html_sidebars = { '**': ['globaltoc.html', 'relations.html',
-                         'sourcelink.html', 'searchbox.html'] }
+html_sidebars = {
+    "**": ["globaltoc.html", "relations.html", "sourcelink.html", "searchbox.html"]
+}

--- a/docs/source/conventions/computed_identifiers.rst
+++ b/docs/source/conventions/computed_identifiers.rst
@@ -26,9 +26,8 @@ A VRS Computed Identifier for a VRS concept is computed as follows:
 .. important:: Normalizing objects is STRONGLY RECOMMENDED for
                interoperability. While normalization is not strictly
                required, automated validation mechanisms are
-               anticipated that will likely disqualify Variation that
-               is not normalized. See :ref:`should-normalize` for
-               a rationale.
+               anticipated that will likely disqualify variations that
+               are not normalized.
 
 The following diagram depicts the operations necessary to generate a
 computed identifier. These operations are described in detail in the

--- a/docs/source/conventions/example.rst
+++ b/docs/source/conventions/example.rst
@@ -198,22 +198,3 @@ This example provides a full VRS-compliant Allele with a computed identifier.
           identifier scheme for private or public use. For example,
           the above *id* could be a serial number assigned by an
           application, such as ``acmecorp:v0000123``.
-
-
-What's Next?
-@@@@@@@@@@@@
-
-This example has shown a full example for a relatively simple case.
-VRS provides a framework that will enable much more complex variation.
-Please see :ref:`future-plans` for a discussion of variation classes
-that are intended in the near future.
-
-The :ref:`implementations` section lists libraries and packages that
-implement VRS.
-
-VRS objects are `value objects
-<https://en.wikipedia.org/wiki/Value_object>`__. An important
-consequence of this design choice is that data should be associated
-*with* VRS objects via their identifiers rather than embedded *within*
-those objects. The appendix contains an example of :ref:`associating
-annotations with variation <associating_annotations>`.

--- a/docs/source/conventions/example.rst
+++ b/docs/source/conventions/example.rst
@@ -19,7 +19,7 @@ reference nucleotide ``C`` to ``T``.
 
 In VRS, a contiguous change is represented using an :ref:`allele`
 object, which is composed of a :ref:`Location <location>` and of the
-:ref:`State <state>` at that location. Location and State are
+:ref:`State <SequenceExpression>` at that location. Location and State are
 abstract concepts: VRS is designed to accommodate many kinds of
 Locations based on sequence position, gene names, cytogenetic bands, or
 other ways of describing locations. Similarly, State may refer to a

--- a/docs/source/conventions/required_data.rst
+++ b/docs/source/conventions/required_data.rst
@@ -84,10 +84,10 @@ supported. The data proxy interface defines three methods:
   sequence identifier, return all aliases in the specified
   namespace. Zero or more aliases may be returned.
 
-The :ref:`impl-vrs-python` `DataProxy class
+The |vrs-python| `DataProxy class
 <https://github.com/ga4gh/vrs-python/blob/main/src/ga4gh/vrs/dataproxy.py>`__
 provides an example of this design pattern and sample replies.
-|vrs-python| implements the DataProxy interface using a local
+VRS-Python implements the DataProxy interface using a local
 |seqrepo| instance backend and using a |seqrepo_rs| backend.
 
 Examples

--- a/schema/vrs/def/Allele.rst
+++ b/schema/vrs/def/Allele.rst
@@ -87,7 +87,7 @@ Some Allele attributes are inherited from :ref:`Variation`.
       - MUST be "Allele"
    *  - location
       -
-      - :ref:`iriReference` | :ref:`Location`
+      - :ref:`iriReference` | :ref:`SequenceLocation`
       - 1..1
       - The location of the Allele
    *  - state

--- a/schema/vrs/def/CopyNumberChange.rst
+++ b/schema/vrs/def/CopyNumberChange.rst
@@ -87,7 +87,7 @@ Some CopyNumberChange attributes are inherited from :ref:`Variation`.
       - MUST be "CopyNumberChange"
    *  - location
       -
-      - :ref:`iriReference` | :ref:`Location`
+      - :ref:`iriReference` | :ref:`SequenceLocation`
       - 1..1
       - The location of the subject of the copy change.
    *  - copyChange

--- a/schema/vrs/def/ReferenceLengthExpression.rst
+++ b/schema/vrs/def/ReferenceLengthExpression.rst
@@ -81,7 +81,7 @@ Some ReferenceLengthExpression attributes are inherited from :ref:`SequenceExpre
       -
       - :ref:`sequenceString`
       - 0..1
-      - the literal :ref:`Sequence` encoded by the Reference Length Expression.
+      - the literal :ref:`sequence <sequenceString>` encoded by the Reference Length Expression.
    *  - repeatSubunitLength
       -
       - integer

--- a/schema/vrs/def/RelativeAllele.rst
+++ b/schema/vrs/def/RelativeAllele.rst
@@ -1,10 +1,10 @@
-.. note:: This data class is at a **trial use** maturity level and may \
-    change in future releases. Maturity \
+.. warning:: This data class is at a **draft** maturity level and may \
+    change significantly in future releases. Maturity \
     levels are described in the :ref:`maturity-model`.
 
 **Computational Definition**
 
-The absolute count of discrete copies of a :ref:`Location` within a system (e.g. genome, cell, etc.).
+An Allele defined on a mapped location relative to a base location. Often used to describe intronic variants.
 
 **GA4GH Digest**
 
@@ -17,13 +17,13 @@ The absolute count of discrete copies of a :ref:`Location` within a system (e.g.
     *  - Prefix
        - Inherent
 
-    *  - CN
-       - ['copies', 'location', 'type']
+    *  - RA
+       - ['baseState', 'relativeLocation', 'relativeState', 'type']
 
 
 **Information Model**
 
-Some CopyNumberCount attributes are inherited from :ref:`Variation`.
+Some RelativeAllele attributes are inherited from :ref:`Variation`.
 
 .. list-table::
    :class: clean-wrap
@@ -84,14 +84,19 @@ Some CopyNumberCount attributes are inherited from :ref:`Variation`.
       -
       - string
       - 1..1
-      - MUST be "CopyNumberCount"
-   *  - location
+      - MUST be "RelativeAllele"
+   *  - relativeState
       -
-      - :ref:`iriReference` | :ref:`SequenceLocation`
-      - 1..1
-      - The location of the subject of the copy count.
-   *  - copies
+      - :ref:`SequenceExpression`
+      - 0..1
+      - The state of the RelativeAllele as expressed on the mapped sequence. This will differ from the base state when mapping to a reverse complement sequence, commonly observed when representing the state on transcripts mapped to the "negative strand" of a chromosome.
+   *  - baseState
       -
-      - integer | :ref:`Range`
-      - 1..1
-      - The integral number of copies of the subject in a system
+      - :ref:`SequenceExpression`
+      - 0..1
+      - The state of the RelativeAllele as expressed on the base sequence.
+   *  - relativeLocation
+      -
+      - :ref:`RelativeSequenceLocation` | :ref:`iriReference`
+      - 0..1
+      - The relative location at which the baseState and relativeState are expressed.

--- a/schema/vrs/def/RelativeSequenceLocation.rst
+++ b/schema/vrs/def/RelativeSequenceLocation.rst
@@ -1,10 +1,10 @@
-.. note:: This data class is at a **trial use** maturity level and may \
-    change in future releases. Maturity \
+.. warning:: This data class is at a **draft** maturity level and may \
+    change significantly in future releases. Maturity \
     levels are described in the :ref:`maturity-model`.
 
 **Computational Definition**
 
-The absolute count of discrete copies of a :ref:`Location` within a system (e.g. genome, cell, etc.).
+A location on a base sequence and its position relative to a boundary offset on a mapped sequence gap. Typically used to describe intronic locations that exist with respect to a mapped RNA transcript sequence.
 
 **GA4GH Digest**
 
@@ -17,13 +17,13 @@ The absolute count of discrete copies of a :ref:`Location` within a system (e.g.
     *  - Prefix
        - Inherent
 
-    *  - CN
-       - ['copies', 'location', 'type']
+    *  - RSL
+       - ['baseSequenceLocation', 'offsetLocation', 'type']
 
 
 **Information Model**
 
-Some CopyNumberCount attributes are inherited from :ref:`Variation`.
+Some RelativeSequenceLocation attributes are inherited from :ref:`Ga4ghIdentifiableObject`.
 
 .. list-table::
    :class: clean-wrap
@@ -72,26 +72,18 @@ Some CopyNumberCount attributes are inherited from :ref:`Variation`.
       - string
       - 0..1
       - A sha512t24u digest created using the VRS Computed Identifier algorithm.
-   *  - expressions
-      -
-                        .. raw:: html
-
-                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Unordered">&#8942;</span>
-      - :ref:`Expression`
-      - 0..m
-      -
    *  - type
       -
       - string
       - 1..1
-      - MUST be "CopyNumberCount"
-   *  - location
+      - MUST be "RelativeSequenceLocation"
+   *  - baseSequenceLocation
       -
-      - :ref:`iriReference` | :ref:`SequenceLocation`
-      - 1..1
-      - The location of the subject of the copy count.
-   *  - copies
+      - :ref:`SequenceLocation` | :ref:`iriReference`
+      - 0..1
+      - An absolute location on a sequence.
+   *  - mappedSequenceLocation
       -
-      - integer | :ref:`Range`
-      - 1..1
-      - The integral number of copies of the subject in a system
+      - :ref:`iriReference` | :ref:`SequenceOffsetLocation`
+      - 0..1
+      - A location relative to an offset on a mapped sequence.

--- a/schema/vrs/def/SequenceExpression.rst
+++ b/schema/vrs/def/SequenceExpression.rst
@@ -4,7 +4,7 @@
 
 **Computational Definition**
 
-An expression describing a :ref:`Sequence`.
+An expression describing a :ref:`sequence <sequenceString>`.
 
 **GA4GH Digest**
 

--- a/schema/vrs/def/SequenceOffsetLocation.rst
+++ b/schema/vrs/def/SequenceOffsetLocation.rst
@@ -1,29 +1,14 @@
-.. note:: This data class is at a **trial use** maturity level and may \
-    change in future releases. Maturity \
+.. warning:: This data class is at a **draft** maturity level and may \
+    change significantly in future releases. Maturity \
     levels are described in the :ref:`maturity-model`.
 
 **Computational Definition**
 
-The absolute count of discrete copies of a :ref:`Location` within a system (e.g. genome, cell, etc.).
-
-**GA4GH Digest**
-
-.. list-table::
-    :class: clean-wrap
-    :header-rows: 1
-    :align: left
-    :widths: auto
-
-    *  - Prefix
-       - Inherent
-
-    *  - CN
-       - ['copies', 'location', 'type']
-
+A location defined by an offset relative to an anchor on a mapped sequence reference.
 
 **Information Model**
 
-Some CopyNumberCount attributes are inherited from :ref:`Variation`.
+Some SequenceOffsetLocation attributes are inherited from :ref:`gks-core:Entity`.
 
 .. list-table::
    :class: clean-wrap
@@ -67,31 +52,33 @@ Some CopyNumberCount attributes are inherited from :ref:`Variation`.
       - :ref:`Extension`
       - 0..m
       - A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.
-   *  - digest
-      -
-      - string
-      - 0..1
-      - A sha512t24u digest created using the VRS Computed Identifier algorithm.
-   *  - expressions
-      -
-                        .. raw:: html
-
-                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Unordered">&#8942;</span>
-      - :ref:`Expression`
-      - 0..m
-      -
    *  - type
       -
       - string
       - 1..1
-      - MUST be "CopyNumberCount"
-   *  - location
+      - MUST be "SequenceOffset"
+   *  - sequenceReference
       -
-      - :ref:`iriReference` | :ref:`SequenceLocation`
-      - 1..1
-      - The location of the subject of the copy count.
-   *  - copies
+      - :ref:`SequenceReference` | :ref:`iriReference`
+      - 0..1
+      - A sequence reference that has been mapped from which a relative location is defined.
+   *  - anchor
+      -
+      - integer
+      - 0..1
+      - The position on the sequence reference from which the relative location offset is calculated.
+   *  - anchorOrientation
+      -
+      - string
+      - 0..1
+      - Indicates which side of a discontinuous anchor on the sequenceReference is used as the reference point for interpreting offsetStart/offsetEnd. The anchor is an inter-residue coordinate on the sequenceReference. When that anchor corresponds to a boundary whose realization on a base sequence yields two distinct locations (e.g., an exon junction), this property disambiguates which anchor side on the sequenceReference is intended. `left` denotes the side immediately preceding the anchor in sequenceReference coordinate order; `right` denotes the side immediately following the anchor in sequenceReference coordinate order.
+   *  - offsetStart
       -
       - integer | :ref:`Range`
-      - 1..1
-      - The integral number of copies of the subject in a system
+      - 0..1
+      - The start offset, in inter-residue coordinates, from the anchor realization selected by anchorOrientation on the sequenceReference.
+   *  - offsetEnd
+      -
+      - integer | :ref:`Range`
+      - 0..1
+      - The end offset, in inter-residue coordinates, from the anchor realization selected by anchorOrientation on the sequenceReference.

--- a/schema/vrs/json/Adjacency
+++ b/schema/vrs/json/Adjacency
@@ -69,6 +69,9 @@
          "items": {
             "oneOf": [
                {
+                  "$ref": "/ga4gh/schema/vrs/2.0.1/json/RelativeSequenceLocation"
+               },
+               {
                   "$ref": "/ga4gh/schema/vrs/2.0.1/json/SequenceLocation"
                },
                {

--- a/schema/vrs/json/Location
+++ b/schema/vrs/json/Location
@@ -7,6 +7,9 @@
    "description": "A contiguous segment of a biological sequence.",
    "oneOf": [
       {
+         "$ref": "/ga4gh/schema/vrs/2.0.1/json/RelativeSequenceLocation"
+      },
+      {
          "$ref": "/ga4gh/schema/vrs/2.0.1/json/SequenceLocation"
       }
    ],

--- a/schema/vrs/json/MolecularVariation
+++ b/schema/vrs/json/MolecularVariation
@@ -19,6 +19,9 @@
          "$ref": "/ga4gh/schema/vrs/2.0.1/json/DerivativeMolecule"
       },
       {
+         "$ref": "/ga4gh/schema/vrs/2.0.1/json/RelativeAllele"
+      },
+      {
          "$ref": "/ga4gh/schema/vrs/2.0.1/json/Terminus"
       }
    ],

--- a/schema/vrs/json/ReferenceLengthExpression
+++ b/schema/vrs/json/ReferenceLengthExpression
@@ -63,7 +63,7 @@
       },
       "sequence": {
          "$ref": "/ga4gh/schema/vrs/2.0.1/json/sequenceString",
-         "description": "the literal Sequence encoded by the Reference Length Expression."
+         "description": "the literal sequence encoded by the Reference Length Expression."
       },
       "repeatSubunitLength": {
          "type": "integer",

--- a/schema/vrs/json/RelativeAllele
+++ b/schema/vrs/json/RelativeAllele
@@ -1,17 +1,19 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.1/json/Terminus",
-   "title": "Terminus",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.1/json/RelativeAllele",
+   "title": "RelativeAllele",
    "type": "object",
    "maturity": "draft",
    "ga4gh": {
-      "prefix": "TM",
+      "prefix": "RA",
       "inherent": [
-         "location",
+         "baseState",
+         "relativeLocation",
+         "relativeState",
          "type"
       ]
    },
-   "description": "The `Terminus` data class provides a structure for describing the end (terminus) of a molecule. Structurally similar to Adjacency, but used for describing where a molecule terminates (instead of adjoining another molecule).",
+   "description": "An Allele defined on a mapped location relative to a base location. Often used to describe intronic variants.",
    "properties": {
       "id": {
          "type": "string",
@@ -57,27 +59,51 @@
       },
       "type": {
          "type": "string",
-         "const": "Terminus",
-         "default": "Terminus",
-         "description": "MUST be \"Terminus\"."
+         "const": "RelativeAllele",
+         "default": "RelativeAllele",
+         "description": "MUST be \"RelativeAllele\""
       },
-      "location": {
+      "relativeState": {
+         "description": "The state of the RelativeAllele as expressed on the mapped sequence. This will differ from the base state when mapping to a reverse complement sequence, commonly observed when representing the state on transcripts mapped to the \"negative strand\" of a chromosome.",
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/LengthExpression"
+            },
+            {
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/LiteralSequenceExpression"
+            },
+            {
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/ReferenceLengthExpression"
+            }
+         ]
+      },
+      "baseState": {
+         "description": "The state of the RelativeAllele as expressed on the base sequence.",
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/LengthExpression"
+            },
+            {
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/LiteralSequenceExpression"
+            },
+            {
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/ReferenceLengthExpression"
+            }
+         ]
+      },
+      "relativeLocation": {
+         "description": "The relative location at which the baseState and relativeState are expressed.",
          "oneOf": [
             {
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/RelativeSequenceLocation"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/SequenceLocation"
-            },
-            {
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             }
-         ],
-         "description": "The location of the terminus."
+         ]
       }
    },
    "required": [
-      "location",
       "type"
    ],
    "additionalProperties": false

--- a/schema/vrs/json/RelativeSequenceLocation
+++ b/schema/vrs/json/RelativeSequenceLocation
@@ -1,17 +1,18 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.1/json/Terminus",
-   "title": "Terminus",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.1/json/RelativeSequenceLocation",
+   "title": "RelativeSequenceLocation",
    "type": "object",
    "maturity": "draft",
    "ga4gh": {
-      "prefix": "TM",
       "inherent": [
-         "location",
+         "baseSequenceLocation",
+         "offsetLocation",
          "type"
-      ]
+      ],
+      "prefix": "RSL"
    },
-   "description": "The `Terminus` data class provides a structure for describing the end (terminus) of a molecule. Structurally similar to Adjacency, but used for describing where a molecule terminates (instead of adjoining another molecule).",
+   "description": "A location on a base sequence and its position relative to a boundary offset on a mapped sequence gap. Typically used to describe intronic locations that exist with respect to a mapped RNA transcript sequence.",
    "properties": {
       "id": {
          "type": "string",
@@ -48,36 +49,36 @@
          "type": "string",
          "pattern": "^[0-9A-Za-z_\\-]{32}$"
       },
-      "expressions": {
-         "type": "array",
-         "ordered": false,
-         "items": {
-            "$ref": "/ga4gh/schema/vrs/2.0.1/json/Expression"
-         }
-      },
       "type": {
          "type": "string",
-         "const": "Terminus",
-         "default": "Terminus",
-         "description": "MUST be \"Terminus\"."
+         "const": "RelativeSequenceLocation",
+         "default": "RelativeSequenceLocation",
+         "description": "MUST be \"RelativeSequenceLocation\""
       },
-      "location": {
+      "baseSequenceLocation": {
+         "description": "An absolute location on a sequence.",
          "oneOf": [
-            {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/RelativeSequenceLocation"
-            },
             {
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/SequenceLocation"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             }
-         ],
-         "description": "The location of the terminus."
+         ]
+      },
+      "mappedSequenceLocation": {
+         "description": "A location relative to an offset on a mapped sequence.",
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/SequenceOffsetLocation"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+            }
+         ]
       }
    },
    "required": [
-      "location",
       "type"
    ],
    "additionalProperties": false

--- a/schema/vrs/json/SequenceExpression
+++ b/schema/vrs/json/SequenceExpression
@@ -4,7 +4,7 @@
    "title": "SequenceExpression",
    "type": "object",
    "maturity": "trial use",
-   "description": "An expression describing a Sequence.",
+   "description": "An expression describing a sequence.",
    "oneOf": [
       {
          "$ref": "/ga4gh/schema/vrs/2.0.1/json/LengthExpression"

--- a/schema/vrs/json/SequenceOffsetLocation
+++ b/schema/vrs/json/SequenceOffsetLocation
@@ -1,0 +1,96 @@
+{
+   "$schema": "https://json-schema.org/draft/2020-12/schema",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/2.0.1/json/SequenceOffsetLocation",
+   "title": "SequenceOffsetLocation",
+   "type": "object",
+   "maturity": "draft",
+   "description": "A location defined by an offset relative to an anchor on a mapped sequence reference.",
+   "properties": {
+      "id": {
+         "type": "string",
+         "description": "The 'logical' identifier of the Entity in the system of record, e.g. a UUID.  This 'id' is unique within a given system, but may or may not be globally unique outside the system. It is used within a system to reference an object from another.",
+         "$comment": "Note that it is common for implementers to create their own internal logical ids - typically a serially or randomly generated value like a UUID that is assigned to the data object as it is created in a system. But an implementer may choose to re-use an existing, globally unique id from an external system or authority for this purpose (e.g. an HGNC id for a Gene object) - as long as it is unique within the implementing system, and can be used to reference the identified object in this context."
+      },
+      "name": {
+         "type": "string",
+         "description": "A primary name for the entity."
+      },
+      "description": {
+         "type": "string",
+         "description": "A free-text description of the Entity."
+      },
+      "aliases": {
+         "type": "array",
+         "ordered": false,
+         "items": {
+            "type": "string"
+         },
+         "description": "Alternative name(s) for the Entity."
+      },
+      "extensions": {
+         "type": "array",
+         "ordered": false,
+         "items": {
+            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+         },
+         "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
+         "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
+      },
+      "type": {
+         "type": "string",
+         "description": "MUST be \"SequenceOffset\"",
+         "$comment": "MUST be the name of a concrete class from the data model.",
+         "const": "SequenceOffset",
+         "default": "SequenceOffset"
+      },
+      "sequenceReference": {
+         "description": "A sequence reference that has been mapped from which a relative location is defined.",
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/SequenceReference"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+            }
+         ]
+      },
+      "anchor": {
+         "description": "The position on the sequence reference from which the relative location offset is calculated.",
+         "type": "integer"
+      },
+      "anchorOrientation": {
+         "description": "Indicates which side of a discontinuous anchor on the sequenceReference is used as the reference point for interpreting offsetStart/offsetEnd. The anchor is an inter-residue coordinate on the sequenceReference. When that anchor corresponds to a boundary whose realization on a base sequence yields two distinct locations (e.g., an exon junction), this property disambiguates which anchor side on the sequenceReference is intended. `left` denotes the side immediately preceding the anchor in sequenceReference coordinate order; `right` denotes the side immediately following the anchor in sequenceReference coordinate order.",
+         "type": "string",
+         "enum": [
+            "left",
+            "right"
+         ]
+      },
+      "offsetStart": {
+         "description": "The start offset, in inter-residue coordinates, from the anchor realization selected by anchorOrientation on the sequenceReference.",
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/Range"
+            },
+            {
+               "type": "integer"
+            }
+         ]
+      },
+      "offsetEnd": {
+         "description": "The end offset, in inter-residue coordinates, from the anchor realization selected by anchorOrientation on the sequenceReference.",
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/Range"
+            },
+            {
+               "type": "integer"
+            }
+         ]
+      }
+   },
+   "required": [
+      "type"
+   ],
+   "additionalProperties": false
+}

--- a/schema/vrs/json/Variation
+++ b/schema/vrs/json/Variation
@@ -25,6 +25,9 @@
          "$ref": "/ga4gh/schema/vrs/2.0.1/json/DerivativeMolecule"
       },
       {
+         "$ref": "/ga4gh/schema/vrs/2.0.1/json/RelativeAllele"
+      },
+      {
          "$ref": "/ga4gh/schema/vrs/2.0.1/json/Terminus"
       }
    ],

--- a/schema/vrs/vrs-source.yaml
+++ b/schema/vrs/vrs-source.yaml
@@ -99,6 +99,7 @@ $defs:
       A :ref:`variation` on a contiguous molecule.
     oneOf:
       - $ref: "#/$defs/Allele"
+      - $ref: "#/$defs/RelativeAllele"
       - $ref: "#/$defs/CisPhasedBlock"
       - $ref: "#/$defs/Adjacency"
       - $ref: "#/$defs/Terminus"
@@ -147,7 +148,7 @@ $defs:
       location:
         oneOf:
           - $refCurie: gks.core:iriReference
-          - $ref: "#/$defs/Location"
+          - $ref: "#/$defs/SequenceLocation"
         description: >-
           The location of the Allele
       state:
@@ -155,6 +156,44 @@ $defs:
         description: >-
           An expression of the sequence state
     required: [ "location", "state" ]
+
+  RelativeAllele:
+    maturity: draft
+    ga4gh:
+      prefix: RA
+      inherent:
+        - relativeState
+        - baseState
+        - relativeLocation
+    inherits: MolecularVariation
+    type: object
+    description: >-
+      An Allele defined on a mapped location relative to a base location.
+      Often used to describe intronic variants.
+    properties:
+      type:
+        extends: type
+        const: "RelativeAllele"
+        default: "RelativeAllele"
+        description: >-
+          MUST be "RelativeAllele"
+      relativeState:
+        description: >-
+          The state of the RelativeAllele as expressed on the mapped sequence. This will
+          differ from the base state when mapping to a reverse complement sequence,
+          commonly observed when representing the state on transcripts mapped to the
+          "negative strand" of a chromosome.
+        $ref: "#/$defs/SequenceExpression"
+      baseState:
+        description: >-
+          The state of the RelativeAllele as expressed on the base sequence.
+        $ref: "#/$defs/SequenceExpression"
+      relativeLocation:
+        description: >-
+          The relative location at which the baseState and relativeState are expressed.
+        oneOf:
+          - $ref: "#/$defs/RelativeSequenceLocation"
+          - $refCurie: gks.core:iriReference
 
   CisPhasedBlock:
     maturity: trial use
@@ -218,7 +257,7 @@ $defs:
       location:
         oneOf:
           - $refCurie: gks.core:iriReference
-          - $ref: "#/$defs/Location"
+          - $ref: "#/$defs/SequenceLocation"
         description: >-
           The location of the subject of the copy count.
       copies:
@@ -251,7 +290,7 @@ $defs:
       location:
         oneOf:
           - $refCurie: gks.core:iriReference
-          - $ref: "#/$defs/Location"
+          - $ref: "#/$defs/SequenceLocation"
         description: >-
           The location of the subject of the copy change.
       copyChange:
@@ -280,6 +319,7 @@ $defs:
       A contiguous segment of a biological sequence.
     oneOf:
       - $ref: "#/$defs/SequenceLocation"
+      - $ref: "#/$defs/RelativeSequenceLocation"
     discriminator:
       propertyName: type
 
@@ -330,6 +370,98 @@ $defs:
         description: >-
           The literal sequence encoded by the `sequenceReference` at these coordinates.
         $ref: "#/$defs/sequenceString"
+
+  RelativeSequenceLocation:
+    maturity: draft
+    ga4gh:
+      inherent:
+        - baseSequenceLocation
+        - offsetLocation
+      prefix: RSL
+    inherits: Location
+    description: >-
+      A location on a base sequence and its position relative to a boundary
+      offset on a mapped sequence gap. Typically used to describe intronic
+      locations that exist with respect to a mapped RNA transcript sequence.
+    type: object
+    properties:
+      type:
+        extends: type
+        const: "RelativeSequenceLocation"
+        default: "RelativeSequenceLocation"
+        description: MUST be "RelativeSequenceLocation"
+      baseSequenceLocation:
+        description: >-
+          An absolute location on a sequence.
+        oneOf:
+          - $ref: "#/$defs/SequenceLocation"
+          - $refCurie: gks.core:iriReference
+      mappedSequenceLocation:
+        description: >-
+          A location relative to an offset on a mapped sequence.
+        oneOf:
+          - $refCurie: gks.core:iriReference
+          - $ref: "#/$defs/SequenceOffsetLocation"
+
+  SequenceOffsetLocation:
+    type: object
+    inherits: gks-core:Entity
+    # protectedClassOf: RelativeSequenceLocation
+    maturity: draft
+    description: >-
+      A location defined by an offset relative to an anchor on a
+      mapped sequence reference.
+    properties:
+      type:
+        extends: type
+        const: "SequenceOffset"
+        default: "SequenceOffset"
+        description: MUST be "SequenceOffset"
+      sequenceReference:
+        description: >-
+          A sequence reference that has been mapped from which a
+          relative location is defined.
+        oneOf:
+          - $ref: "#/$defs/SequenceReference"
+          - $refCurie: gks.core:iriReference
+      anchor:
+        description: >-
+          The position on the sequence reference from which the
+          relative location offset is calculated.
+        type: integer
+      anchorOrientation:
+        description: >-
+          Indicates which side of a discontinuous anchor on the
+          sequenceReference is used as the reference point for
+          interpreting offsetStart/offsetEnd. The anchor is an
+          inter-residue coordinate on the sequenceReference. When
+          that anchor corresponds to a boundary whose realization
+          on a base sequence yields two distinct locations (e.g.,
+          an exon junction), this property disambiguates which
+          anchor side on the sequenceReference is intended.
+          `left` denotes the side immediately preceding the anchor
+          in sequenceReference coordinate order; `right` denotes the
+          side immediately following the anchor in sequenceReference
+          coordinate order.
+        type: string
+        enum: ['left', 'right']
+      offsetStart:
+        description: >-
+          The start offset, in inter-residue coordinates, from the
+          anchor realization selected by anchorOrientation on the
+          sequenceReference.
+        oneOf:
+          - type: integer
+          - $ref: "#/$defs/Range"
+      offsetEnd:
+        description: >-
+          The end offset, in inter-residue coordinates, from the
+          anchor realization selected by anchorOrientation on the
+          sequenceReference.
+        oneOf:
+          - type: integer
+          - $ref: "#/$defs/Range"
+
 
   SequenceReference:
     maturity: trial use

--- a/schema/vrs/vrs-source.yaml
+++ b/schema/vrs/vrs-source.yaml
@@ -527,7 +527,7 @@ $defs:
       inherent:
         - type
     description: >-
-      An expression describing a :ref:`Sequence`.
+      An expression describing a :ref:`sequence <sequenceString>`.
     oneOf:
       - $ref: "#/$defs/LiteralSequenceExpression"
       - $ref: "#/$defs/ReferenceLengthExpression"
@@ -566,7 +566,7 @@ $defs:
         description: The number of residues in the expressed sequence.
       sequence:
         $ref: "#/$defs/sequenceString"
-        description: the literal :ref:`Sequence` encoded by the Reference Length Expression.
+        description: the literal :ref:`sequence <sequenceString>` encoded by the Reference Length Expression.
       repeatSubunitLength:
         type: integer
         description: The number of residues in the repeat subunit.


### PR DESCRIPTION
* Fix some broken refs. When a `:ref:` is broken, it just renders as the literal (i.e. ``:ref:`gks-development``` -> `gks-development`) which looks kinda bad. In several cases, there were refs to pages that no longer existed in 2.x.
* Remove "what's next" section in the "appendices -> example" page. This included several broken refs and referred to an appendix page that didn't exist anymore. Insofar as it provided relevant information, I didn't think this was a particularly good place to be housing it, so I just wiped the whole section.
* Change several textual and hyperlink references to the VRS 1.x `Sequence` that were still floating around. This one is kind of tricky. VRS 2.x more or less swaps out `Sequence` for `sequenceString`, as far as I can tell, but in some cases the language seemed more like it was describing a physical biological sequence and not a string-encoded version of it, so I tried my best. But I think it could also be safer to just make a clean swap so it just says `sequenceString` everywhere.
* Add the "inter-residue coordinates" section from VRS 1.3 design decisions back. I am not sure if this was removed on purpose or not, but I think it's helpful and there is also a pretty specific reference to it in the "examples" page that deserves additional explanation.