### PR TITLE
docs: fix refs, add warnings check to CI/CD

### DIFF
--- a/.github/workflows/cqa.yaml
+++ b/.github/workflows/cqa.yaml
@@ -22,3 +22,20 @@ jobs:
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: ${{ matrix.cmd }} --all-files
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.13
+
+      - name: install dependencies
+        run: python3 -m pip install -r .requirements.txt
+
+      - name: attempt docs build
+        working-directory: docs
+        run: make all

--- a/.github/workflows/cqa.yaml
+++ b/.github/workflows/cqa.yaml
@@ -38,4 +38,4 @@ jobs:
 
       - name: attempt docs build
         working-directory: docs
-        run: make all SPHINXOPTS="-W"
+        run: make html SPHINXOPTS="-W"

--- a/.github/workflows/cqa.yaml
+++ b/.github/workflows/cqa.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: generate schema
         working-directory: schema
-        run: make schema
+        run: make all
 
       - name: attempt docs build
         working-directory: docs

--- a/.github/workflows/cqa.yaml
+++ b/.github/workflows/cqa.yaml
@@ -38,4 +38,4 @@ jobs:
 
       - name: attempt docs build
         working-directory: docs
-        run: make all
+        run: make all SPHINXOPTS="-W"

--- a/.github/workflows/cqa.yaml
+++ b/.github/workflows/cqa.yaml
@@ -36,6 +36,10 @@ jobs:
       - name: install dependencies
         run: python3 -m pip install -r .requirements.txt
 
+      - name: generate schema
+        working-directory: schema
+        run: make schema
+
       - name: attempt docs build
         working-directory: docs
         run: make html SPHINXOPTS="-W"

--- a/docs/source/appendices/design_decisions.rst
+++ b/docs/source/appendices/design_decisions.rst
@@ -91,6 +91,34 @@ the following syntax:
 
   https://w3id.org/ga4gh/vrs/VA.Oop4kjdTtKcg1kiZjIJAAR3bp7qi4aNT
 
+.. _inter-residue-coordinates-design:
+
+Inter-residue Coordinates
+@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+Sequence ranges use an inter-residue coordinate system. Inter-residue
+coordinate conventions are used in this terminology because they
+provide conceptual consistency that is not possible with residue-based
+systems.
+
+.. important:: The choice of what to count — residue or inter-residue
+               positions — has significant semantic implications for
+               the interpretation of coordinates.  Although
+               inter-residue coordinates and the "0-based" residue
+               coordinates are often numerically identical, we favor
+               "inter-residue" to emphasize the meaning of these
+               coordinates.
+
+When humans refer to a range of residues within a sequence, the most
+common convention is to use an interval of ordinal residue positions
+in the sequence. While natural for humans, this convention has several
+shortcomings when dealing with sequence variation.
+
+For example, interval coordinates are interpreted as exclusive
+coordinates for insertions, but as inclusive coordinates for
+substitutions and deletions; in effect, the interpretation of
+coordinates depends on the variant type, which is an unfortunate
+coupling of distinct concepts.
 Use of value sets for VRS computed digests
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 

--- a/docs/source/appendices/maturity_model.rst
+++ b/docs/source/appendices/maturity_model.rst
@@ -75,7 +75,7 @@ or may emerge in the course of technical specification development. It is expect
 that the need for product features are first discussed in a community forum (e.g.
 GitHub Discussions, GKS Work Stream calls).
 
-**Process**: Follow the GKS :ref:`development-process`. As part of this process,
+**Process**: Follow the GKS development process. As part of this process,
 it is expected that consensus among the decision-makers was reached and major design
 decisions documented. Disagreements are resolved per Work Stream and GA4GH processes.
 

--- a/docs/source/concepts/AdditionalDataTypes/index.rst
+++ b/docs/source/concepts/AdditionalDataTypes/index.rst
@@ -155,7 +155,7 @@ code
 ####
 *imported*
 
-.. include::  ../../def/gks-core/Code.rst
+.. include::  ../../def/gks-core/code.rst
 
 .. _iriReference:
 

--- a/docs/source/concepts/LocationAndReference/SequenceLocation.rst
+++ b/docs/source/concepts/LocationAndReference/SequenceLocation.rst
@@ -87,8 +87,6 @@ represents a coding transcript, then the coordinates refer to the coding transcr
 chromosome sequence to which it aligns. VRS intentionally does not allow for *start* or *end* values
 that use an offset system to represent sequence not found on the :ref:`SequenceReference`.
 
-.. TODO:: Describe and add a ref to an intronic variant profile
-
 CisPhasedBlocks and the Inferred SequenceReference
 ##################################################
 

--- a/docs/source/concepts/SequenceExpression/LiteralSequenceExpression.rst
+++ b/docs/source/concepts/SequenceExpression/LiteralSequenceExpression.rst
@@ -3,7 +3,7 @@
 Literal Sequence Expression
 !!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-A literal sequence expression is a literal representation of a :ref:`Sequence`.
+A literal sequence expression is a literal representation of a :ref:`sequence <sequenceString>`.
 
 Definition and Information Model
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,16 +16,22 @@ import subprocess
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+
 def _get_git_tag():
-    res = subprocess.run("git describe --tags --exact-match".split(), capture_output=True)
+    res = subprocess.run(
+        "git describe --tags --exact-match".split(), capture_output=True
+    )
     if res.stderr.decode().startswith("fatal"):
         # if no exact tag, then get branch
-        res = subprocess.run("git rev-parse --abbrev-ref HEAD".split(), capture_output=True)
+        res = subprocess.run(
+            "git rev-parse --abbrev-ref HEAD".split(), capture_output=True
+        )
     tag = res.stdout.decode().strip()
     return tag
 
+
 def _parse_release_as_version(rls):
-    m = re.match("^(\d+\.\d+)", rls)
+    m = re.match(r"^(\d+\.\d+)", rls)
     if m:
         return m.group(1)
     return rls
@@ -33,10 +39,10 @@ def _parse_release_as_version(rls):
 
 # -- Project information -----------------------------------------------------
 
-project = 'GA4GH Variation Representation Specification'
-copyright = '2021, GA4GH VRS Contributors'
-author = 'Committers'
-master_doc = 'index'
+project = "GA4GH Variation Representation Specification"
+copyright = "2021, GA4GH VRS Contributors"
+author = "Committers"
+master_doc = "index"
 # N.B. RTD ignores these values. :-/
 release = _get_git_tag()
 version = _parse_release_as_version(release)
@@ -46,7 +52,7 @@ github_version = os.environ.get("READTHEDOCS_VERSION", "main")
 
 # -- Schema doc paths --------------------------------------------------------
 
-rst_epilog_fn = os.path.join(os.path.dirname(__file__), 'rst_epilog')
+rst_epilog_fn = os.path.join(os.path.dirname(__file__), "rst_epilog")
 rst_epilog = open(rst_epilog_fn).read().format(release=release)
 
 # -- General configuration ---------------------------------------------------
@@ -54,12 +60,10 @@ rst_epilog = open(rst_epilog_fn).read().format(release=release)
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    'sphinx.ext.todo'
-]
+extensions = ["sphinx.ext.todo"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -78,12 +82,10 @@ todo_emit_warnings = True
 # The theme to use for HTML and HTML Help pages. See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
-html_logo = 'images/GA-logo.png'
+html_theme = "sphinx_rtd_theme"
+html_logo = "images/GA-logo.png"
 
-html_theme_options = {
-    'collapse_navigation': False
-}
+html_theme_options = {"collapse_navigation": False}
 html_context = {
     "conf_py_path": "/docs/source/",
     "display_github": True,
@@ -95,11 +97,12 @@ html_context = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
-html_css_files = ['theme_overrides.css']
+html_css_files = ["theme_overrides.css"]
 
 # Sidebars
 
-html_sidebars = { '**': ['globaltoc.html', 'relations.html',
-                         'sourcelink.html', 'searchbox.html'] }
+html_sidebars = {
+    "**": ["globaltoc.html", "relations.html", "sourcelink.html", "searchbox.html"]
+}

--- a/docs/source/conventions/computed_identifiers.rst
+++ b/docs/source/conventions/computed_identifiers.rst
@@ -26,9 +26,8 @@ A VRS Computed Identifier for a VRS concept is computed as follows:
 .. important:: Normalizing objects is STRONGLY RECOMMENDED for
                interoperability. While normalization is not strictly
                required, automated validation mechanisms are
-               anticipated that will likely disqualify Variation that
-               is not normalized. See :ref:`should-normalize` for
-               a rationale.
+               anticipated that will likely disqualify variations that
+               are not normalized.
 
 The following diagram depicts the operations necessary to generate a
 computed identifier. These operations are described in detail in the

--- a/docs/source/conventions/example.rst
+++ b/docs/source/conventions/example.rst
@@ -198,22 +198,3 @@ This example provides a full VRS-compliant Allele with a computed identifier.
           identifier scheme for private or public use. For example,
           the above *id* could be a serial number assigned by an
           application, such as ``acmecorp:v0000123``.
-
-
-What's Next?
-@@@@@@@@@@@@
-
-This example has shown a full example for a relatively simple case.
-VRS provides a framework that will enable much more complex variation.
-Please see :ref:`future-plans` for a discussion of variation classes
-that are intended in the near future.
-
-The :ref:`implementations` section lists libraries and packages that
-implement VRS.
-
-VRS objects are `value objects
-<https://en.wikipedia.org/wiki/Value_object>`__. An important
-consequence of this design choice is that data should be associated
-*with* VRS objects via their identifiers rather than embedded *within*
-those objects. The appendix contains an example of :ref:`associating
-annotations with variation <associating_annotations>`.

--- a/docs/source/conventions/example.rst
+++ b/docs/source/conventions/example.rst
@@ -19,7 +19,7 @@ reference nucleotide ``C`` to ``T``.
 
 In VRS, a contiguous change is represented using an :ref:`allele`
 object, which is composed of a :ref:`Location <location>` and of the
-:ref:`State <state>` at that location. Location and State are
+:ref:`State <SequenceExpression>` at that location. Location and State are
 abstract concepts: VRS is designed to accommodate many kinds of
 Locations based on sequence position, gene names, cytogenetic bands, or
 other ways of describing locations. Similarly, State may refer to a

--- a/docs/source/conventions/required_data.rst
+++ b/docs/source/conventions/required_data.rst
@@ -84,10 +84,10 @@ supported. The data proxy interface defines three methods:
   sequence identifier, return all aliases in the specified
   namespace. Zero or more aliases may be returned.
 
-The :ref:`impl-vrs-python` `DataProxy class
+The |vrs-python| `DataProxy class
 <https://github.com/ga4gh/vrs-python/blob/main/src/ga4gh/vrs/dataproxy.py>`__
 provides an example of this design pattern and sample replies.
-|vrs-python| implements the DataProxy interface using a local
+VRS-Python implements the DataProxy interface using a local
 |seqrepo| instance backend and using a |seqrepo_rs| backend.
 
 Examples

--- a/schema/vrs/def/ReferenceLengthExpression.rst
+++ b/schema/vrs/def/ReferenceLengthExpression.rst
@@ -81,7 +81,7 @@ Some ReferenceLengthExpression attributes are inherited from :ref:`SequenceExpre
       -
       - :ref:`sequenceString`
       - 0..1
-      - the literal :ref:`Sequence` encoded by the Reference Length Expression.
+      - the literal :ref:`sequence <sequenceString>` encoded by the Reference Length Expression.
    *  - repeatSubunitLength
       -
       - integer

--- a/schema/vrs/def/SequenceExpression.rst
+++ b/schema/vrs/def/SequenceExpression.rst
@@ -4,7 +4,7 @@
 
 **Computational Definition**
 
-An expression describing a :ref:`Sequence`.
+An expression describing a :ref:`sequence <sequenceString>`.
 
 **GA4GH Digest**
 

--- a/schema/vrs/json/ReferenceLengthExpression
+++ b/schema/vrs/json/ReferenceLengthExpression
@@ -63,7 +63,7 @@
       },
       "sequence": {
          "$ref": "/ga4gh/schema/vrs/2.0.1/json/sequenceString",
-         "description": "the literal Sequence encoded by the Reference Length Expression."
+         "description": "the literal sequence encoded by the Reference Length Expression."
       },
       "repeatSubunitLength": {
          "type": "integer",

--- a/schema/vrs/json/SequenceExpression
+++ b/schema/vrs/json/SequenceExpression
@@ -4,7 +4,7 @@
    "title": "SequenceExpression",
    "type": "object",
    "maturity": "trial use",
-   "description": "An expression describing a Sequence.",
+   "description": "An expression describing a sequence.",
    "oneOf": [
       {
          "$ref": "/ga4gh/schema/vrs/2.0.1/json/LengthExpression"

--- a/schema/vrs/vrs-source.yaml
+++ b/schema/vrs/vrs-source.yaml
@@ -395,7 +395,7 @@ $defs:
       inherent:
         - type
     description: >-
-      An expression describing a :ref:`Sequence`.
+      An expression describing a :ref:`sequence <sequenceString>`.
     oneOf:
       - $ref: "#/$defs/LiteralSequenceExpression"
       - $ref: "#/$defs/ReferenceLengthExpression"
@@ -434,7 +434,7 @@ $defs:
         description: The number of residues in the expressed sequence.
       sequence:
         $ref: "#/$defs/sequenceString"
-        description: the literal :ref:`Sequence` encoded by the Reference Length Expression.
+        description: the literal :ref:`sequence <sequenceString>` encoded by the Reference Length Expression.
       repeatSubunitLength:
         type: integer
         description: The number of residues in the repeat subunit.


### PR DESCRIPTION
* Add a GitHub action that builds docs with `SPHINXOPTS="-w"`, which means any warnings show up as a failed test. Maybe this will end up being annoying, but I think it'd be good to see. 
* Fix some broken refs. When a `:ref:` is broken, it just renders as the literal (i.e. ``:ref:`gks-development``` -> `gks-development`) which looks kinda bad. In several cases, there were refs to pages that no longer existed in 2.x.
* Remove "what's next" section in the "appendices -> example" page. This included several broken refs and referred to an appendix page that didn't exist anymore. Insofar as it provided relevant information, I didn't think this was a particularly good place to be housing it, so I just wiped the whole section.
* Change several textual and hyperlink references to the VRS 1.x `Sequence` that were still floating around. This one is kind of tricky. VRS 2.x more or less swaps out `Sequence` for `sequenceString`, as far as I can tell, but in some cases the language seemed more like it was describing a physical biological sequence and not a string-encoded version of it, so I tried my best. But I could easily just make the more naive switch of `sequence` to `sequenceString` everywhere as well.
* Add the "inter-residue coordinates" section from VRS 1.3 design decisions back. I am not sure if this was removed on purpose or not, but I think it's helpful and there is also a pretty specific reference to it in the "examples" page that deserves additional explanation.
* Fix a reference that was pointing to `Code.rst` but should've pointed to `code.rst`. This actually worked fine both on my local machine and in the readthedocs build but failed on the github action runner. (I thought the latter 2 both ran on ubuntu so I dunno what happened there)
* Remove a todo, "Describe and add a ref to an intronic variant profile". I dunno, this was the only thing I couldn't fix myself and there's a plugin (enabled 6 years ago) that turns all TODO's into warnings, which result in a failed Actions test. I think it should be converted into an issue so that it doesn't get lost.