### PR TITLE
docs: fix orphaned pages showing up in search results

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,13 +16,19 @@ import subprocess
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+
 def _get_git_tag():
-    res = subprocess.run("git describe --tags --exact-match".split(), capture_output=True)
+    res = subprocess.run(
+        "git describe --tags --exact-match".split(), capture_output=True
+    )
     if res.stderr.decode().startswith("fatal"):
         # if no exact tag, then get branch
-        res = subprocess.run("git rev-parse --abbrev-ref HEAD".split(), capture_output=True)
+        res = subprocess.run(
+            "git rev-parse --abbrev-ref HEAD".split(), capture_output=True
+        )
     tag = res.stdout.decode().strip()
     return tag
+
 
 def _parse_release_as_version(rls):
     m = re.match("^(\d+\.\d+)", rls)
@@ -33,10 +39,10 @@ def _parse_release_as_version(rls):
 
 # -- Project information -----------------------------------------------------
 
-project = 'GA4GH Variation Representation Specification'
-copyright = '2021, GA4GH VRS Contributors'
-author = 'Committers'
-master_doc = 'index'
+project = "GA4GH Variation Representation Specification"
+copyright = "2021, GA4GH VRS Contributors"
+author = "Committers"
+master_doc = "index"
 # N.B. RTD ignores these values. :-/
 release = _get_git_tag()
 version = _parse_release_as_version(release)
@@ -46,7 +52,7 @@ github_version = os.environ.get("READTHEDOCS_VERSION", "main")
 
 # -- Schema doc paths --------------------------------------------------------
 
-rst_epilog_fn = os.path.join(os.path.dirname(__file__), 'rst_epilog')
+rst_epilog_fn = os.path.join(os.path.dirname(__file__), "rst_epilog")
 rst_epilog = open(rst_epilog_fn).read().format(release=release)
 
 # -- General configuration ---------------------------------------------------
@@ -54,17 +60,15 @@ rst_epilog = open(rst_epilog_fn).read().format(release=release)
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    'sphinx.ext.todo'
-]
+extensions = ["sphinx.ext.todo"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["def"]
+exclude_patterns = ["def/**"]
 
 # TODO directive output
 todo_include_todos = True
@@ -78,12 +82,10 @@ todo_emit_warnings = True
 # The theme to use for HTML and HTML Help pages. See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
-html_logo = 'images/GA-logo.png'
+html_theme = "sphinx_rtd_theme"
+html_logo = "images/GA-logo.png"
 
-html_theme_options = {
-    'collapse_navigation': False
-}
+html_theme_options = {"collapse_navigation": False}
 html_context = {
     "conf_py_path": "/docs/source/",
     "display_github": True,
@@ -95,11 +97,12 @@ html_context = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
-html_css_files = ['theme_overrides.css']
+html_css_files = ["theme_overrides.css"]
 
 # Sidebars
 
-html_sidebars = { '**': ['globaltoc.html', 'relations.html',
-                         'sourcelink.html', 'searchbox.html'] }
+html_sidebars = {
+    "**": ["globaltoc.html", "relations.html", "sourcelink.html", "searchbox.html"]
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,19 +16,13 @@ import subprocess
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-
 def _get_git_tag():
-    res = subprocess.run(
-        "git describe --tags --exact-match".split(), capture_output=True
-    )
+    res = subprocess.run("git describe --tags --exact-match".split(), capture_output=True)
     if res.stderr.decode().startswith("fatal"):
         # if no exact tag, then get branch
-        res = subprocess.run(
-            "git rev-parse --abbrev-ref HEAD".split(), capture_output=True
-        )
+        res = subprocess.run("git rev-parse --abbrev-ref HEAD".split(), capture_output=True)
     tag = res.stdout.decode().strip()
     return tag
-
 
 def _parse_release_as_version(rls):
     m = re.match("^(\d+\.\d+)", rls)
@@ -39,10 +33,10 @@ def _parse_release_as_version(rls):
 
 # -- Project information -----------------------------------------------------
 
-project = "GA4GH Variation Representation Specification"
-copyright = "2021, GA4GH VRS Contributors"
-author = "Committers"
-master_doc = "index"
+project = 'GA4GH Variation Representation Specification'
+copyright = '2021, GA4GH VRS Contributors'
+author = 'Committers'
+master_doc = 'index'
 # N.B. RTD ignores these values. :-/
 release = _get_git_tag()
 version = _parse_release_as_version(release)
@@ -52,7 +46,7 @@ github_version = os.environ.get("READTHEDOCS_VERSION", "main")
 
 # -- Schema doc paths --------------------------------------------------------
 
-rst_epilog_fn = os.path.join(os.path.dirname(__file__), "rst_epilog")
+rst_epilog_fn = os.path.join(os.path.dirname(__file__), 'rst_epilog')
 rst_epilog = open(rst_epilog_fn).read().format(release=release)
 
 # -- General configuration ---------------------------------------------------
@@ -60,10 +54,12 @@ rst_epilog = open(rst_epilog_fn).read().format(release=release)
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.todo"]
+extensions = [
+    'sphinx.ext.todo'
+]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ["_templates"]
+templates_path = ['_templates']
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -82,10 +78,12 @@ todo_emit_warnings = True
 # The theme to use for HTML and HTML Help pages. See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_rtd_theme"
-html_logo = "images/GA-logo.png"
+html_theme = 'sphinx_rtd_theme'
+html_logo = 'images/GA-logo.png'
 
-html_theme_options = {"collapse_navigation": False}
+html_theme_options = {
+    'collapse_navigation': False
+}
 html_context = {
     "conf_py_path": "/docs/source/",
     "display_github": True,
@@ -97,12 +95,11 @@ html_context = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = ['_static']
 
-html_css_files = ["theme_overrides.css"]
+html_css_files = ['theme_overrides.css']
 
 # Sidebars
 
-html_sidebars = {
-    "**": ["globaltoc.html", "relations.html", "sourcelink.html", "searchbox.html"]
-}
+html_sidebars = { '**': ['globaltoc.html', 'relations.html',
+                         'sourcelink.html', 'searchbox.html'] }


### PR DESCRIPTION
If you search for a page that exists in `def/` like Allele, the search results will show you the page the definition is embedded in, and also an orphaned (ie outside of the `toctree` version of the file), showing up as "<No title>". This PR fixes the "no title" instance.

<img width="821" height="737" alt="Screenshot 2025-12-26 at 9 33 44 PM" src="https://github.com/user-attachments/assets/d52871dc-bbe4-41a5-817c-4145249ec134" />