### PR TITLE
docs: auto-update copyright year

### DIFF
--- a/.requirements.txt
+++ b/.requirements.txt
@@ -4,8 +4,8 @@ referencing
 ipython
 pyyaml
 ga4gh.gks.metaschema==0.3.2
-sphinx ~= 7.2
-sphinx-rtd-theme ~= 1.2
+sphinx ~= 8.1.3
+sphinx-rtd-theme ~= 3.0.2
 jupyterlab
 notebook
 pre-commit

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,7 @@ def _parse_release_as_version(rls):
 # -- Project information -----------------------------------------------------
 
 project = 'GA4GH Variation Representation Specification'
-copyright = '2021, GA4GH VRS Contributors'
+copyright = '2021-%Y, GA4GH VRS Contributors'
 author = 'Committers'
 master_doc = 'index'
 # N.B. RTD ignores these values. :-/

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,3 +1,3 @@
-sphinx ~= 7.2
 jinja2 == 3.1.4
-sphinx-rtd-theme == 1.3.0
+sphinx ~= 8.1.3
+sphinx-rtd-theme ~= 3.0.2


### PR DESCRIPTION
Sphinx 8.1 introduces support for `%Y` as a way to auto-update the copyright year range, if that's something we care about