### PR TITLE
fix: use correct img.shields.io link for docs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Variation Representation Specification (VRS)
 
 [![DOI](https://zenodo.org/badge/67005248.svg)](https://zenodo.org/badge/latestdoi/67005248)
-[![Read the Docs](https://img.shields.io/readthedocs/vr-spec/1.1)](https://vrs.ga4gh.org/)
+[![Read the Docs](https://img.shields.io/readthedocs/vr-spec)](https://vrs.ga4gh.org/)
 [![tests](https://github.com/ga4gh/vrs/actions/workflows/tests.yml/badge.svg)](https://github.com/ga4gh/vrs/actions/workflows/tests.yml)
 
 The [GA4GH](https://www.ga4gh.org/) [Variation Representation Specification](https://vrs.ga4gh.org/)


### PR DESCRIPTION
## Before
<img width="905" height="97" alt="Screenshot 2026-02-12 at 19 40 44" src="https://github.com/user-attachments/assets/5145bbf6-11fe-4e04-a5eb-b88077759c37" />

## After
<img width="905" height="97" alt="Screenshot 2026-02-12 at 19 40 36" src="https://github.com/user-attachments/assets/c36f51f3-438d-48d0-934e-8c478355338d" />
