### PR TITLE
test: add tests for ensuring correct properties

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,23 @@
+import json
 from ga4gh.gks.metaschema.tools.source_proc import YamlSchemaProcessor
+import pytest
 
-from config import vrs_source_path, validator
+from config import vrs_source_path, validator, root_path
+
+
+@pytest.fixture(scope="module")
+def json_schema():
+    """Create test fixture for JSON schema"""
+    schemas = {}
+    json_schema_dir = root_path / "schema" / "vrs" / "json"
+
+    for path in json_schema_dir.iterdir():
+        with open(path) as f:
+            schemas[path.stem] = json.load(f)
+
+    return schemas
+
+
 
 # Is the YAML parseable?
 p = YamlSchemaProcessor(vrs_source_path)
@@ -47,3 +64,52 @@ def test_simple_sequence_location():
         'type': 'Allele'
     }
     validator['Allele'].validate(a)
+
+
+def load_all_json_schemas():
+    schemas = {}
+
+    for path in (root_path / "schema" / "vrs" / "json").iterdir():
+        with open(path) as f:
+            schema = json.load(f)
+
+        class_name = path.stem
+        schemas[class_name] = schema
+    return schemas
+
+
+def test_ga4gh_inherent_properties_exist(json_schema):
+    for class_name, schema in json_schema.items():
+        ga4gh_block = schema.get("ga4gh", {})
+        inherent = ga4gh_block.get("inherent")
+
+        if not inherent:
+            continue
+
+        class_properties = set(schema.get("properties", {}).keys())
+        missing = set(inherent) - class_properties
+
+        assert not missing, (
+            f"{class_name} ga4gh.inherent properties not found in properties: {missing}"
+        )
+
+
+def test_type_property_matches_class_name(json_schema):
+    for class_name, schema in json_schema.items():
+        properties = schema.get("properties", {})
+
+        if "type" not in properties:
+            continue
+
+        type_prop = properties["type"]
+        const_value = type_prop.get("const")
+        assert const_value
+
+        default_value = type_prop.get("default")
+        assert default_value
+
+        assert default_value == const_value
+
+        assert const_value == class_name, (
+            f"{class_name} has mismatched type const: expected '{class_name}', got '{const_value}'"
+        )


### PR DESCRIPTION
close #683

* Ensure that ga4gh.inherent properties actually exist in the model (sometimes properties get renamed, but forget to update this field)
* Ensure that the type property matches the class name (this seems to be the convention)
