### PR TITLE
Thinktank examples wip

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,7 @@ tools with VRS.
 To run the smoke tests:
 
     make test
+
+## Sample Data
+
+Example VRS objects, illustrating many variant types, are available in both YAML and JSON format in [examples](./examples).  These objects serve to both illustrate the variant types, and to serve as a starting point for developers who are incorporating VRS into their own software.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -3,4 +3,4 @@
 Quick Start
 !!!!!!!!!!!
 
-The best way to get started with VRS is to check out our educational |notebooks|.
+The best way to get started with VRS is to check out our educational |notebooks|. There are also example data available in the VRS repository at (https://github.com/ga4gh/vrs/examples).

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,6 @@
+# Example data
+
+This directory contains a variety of examples of variants represented in VRS,
+available in formats including YAML and JSON.  These data are provided to
+illustrate VRS objects, and to provide test data for building new applications.
+More information on these examples are available in [this link](../tests/test_definitions.yaml).

--- a/examples/SPDI_contraction.json
+++ b/examples/SPDI_contraction.json
@@ -1,0 +1,25 @@
+{
+  "type": "Allele",
+  "expressions": [
+    {
+      "syntax": "spdi",
+      "value": "NC_000001.11:40819438:CTCCTCCT:CTCCT"
+    }
+  ],
+  "location": {
+    "type": "SequenceLocation",
+    "sequenceReference": {
+      "type": "SequenceReference",
+      "refgetAccession": "SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO",
+      "residueAlphabet": "na",
+      "id": "NC_000001.11"
+    },
+    "start": 40819438,
+    "end": 40819446
+  },
+  "state": {
+    "type": "ReferenceLengthExpression",
+    "length": 5,
+    "repeatSubunitLength": 3
+  }
+}

--- a/examples/SPDI_expansion.json
+++ b/examples/SPDI_expansion.json
@@ -1,0 +1,25 @@
+{
+  "type": "Allele",
+  "expressions": [
+    {
+      "syntax": "spdi",
+      "value": "NC_000001.11:40819438:CTCCTCCT:CTCCTCCTCCT"
+    }
+  ],
+  "location": {
+    "type": "SequenceLocation",
+    "sequenceReference": {
+      "type": "SequenceReference",
+      "refgetAccession": "SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO",
+      "residueAlphabet": "na",
+      "id": "NC_000001.11"
+    },
+    "start": 40819438,
+    "end": 40819446
+  },
+  "state": {
+    "type": "ReferenceLengthExpression",
+    "length": 11,
+    "repeatSubunitLength": 3
+  }
+}

--- a/examples/ambiguous_linker.json
+++ b/examples/ambiguous_linker.json
@@ -1,0 +1,30 @@
+{
+  "id": "ambiguous_linker",
+  "type": "Adjacency",
+  "linker": {
+    "type": "LengthExpression",
+    "length": 20000
+  },
+  "adjoinedSequences": [
+    {
+      "type": "SequenceLocation",
+      "sequenceReference": {
+        "type": "SequenceReference",
+        "refgetAccession": "SQ.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU",
+        "residueAlphabet": "na",
+        "id": "NC_000001.10"
+      },
+      "end": 123
+    },
+    {
+      "type": "SequenceLocation",
+      "sequenceReference": {
+        "type": "SequenceReference",
+        "refgetAccession": "SQ.9KdcA9ZpY1Cpvxvg8bMSLYDUpsX6GDLO",
+        "residueAlphabet": "na",
+        "id": "NC_000002.11"
+      },
+      "start": 456
+    }
+  ]
+}

--- a/examples/invalid_adjacency.json
+++ b/examples/invalid_adjacency.json
@@ -1,0 +1,27 @@
+{
+  "id": "simple_breakpoint",
+  "type": "Adjacency",
+  "adjoinedSequences": [
+    {
+      "type": "SequenceLocation",
+      "sequenceReference": {
+        "type": "SequenceReference",
+        "refgetAccession": "SQ.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU",
+        "residueAlphabet": "na",
+        "id": "NC_000001.10"
+      },
+      "start": 100,
+      "end": 200
+    },
+    {
+      "type": "SequenceLocation",
+      "sequenceReference": {
+        "type": "SequenceReference",
+        "refgetAccession": "SQ.9KdcA9ZpY1Cpvxvg8bMSLYDUpsX6GDLO",
+        "residueAlphabet": "na",
+        "id": "NC_000002.11"
+      },
+      "start": 456
+    }
+  ]
+}

--- a/examples/precise_linker.json
+++ b/examples/precise_linker.json
@@ -1,0 +1,30 @@
+{
+  "id": "precise_linker",
+  "type": "Adjacency",
+  "linker": {
+    "type": "LiteralSequenceExpression",
+    "sequence": "CCCGTC"
+  },
+  "adjoinedSequences": [
+    {
+      "type": "SequenceLocation",
+      "sequenceReference": {
+        "type": "SequenceReference",
+        "refgetAccession": "SQ.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU",
+        "residueAlphabet": "na",
+        "id": "NC_000001.10"
+      },
+      "end": 123
+    },
+    {
+      "type": "SequenceLocation",
+      "sequenceReference": {
+        "type": "SequenceReference",
+        "refgetAccession": "SQ.9KdcA9ZpY1Cpvxvg8bMSLYDUpsX6GDLO",
+        "residueAlphabet": "na",
+        "id": "NC_000002.11"
+      },
+      "start": 456
+    }
+  ]
+}

--- a/examples/revcomp_breakpoint.json
+++ b/examples/revcomp_breakpoint.json
@@ -1,0 +1,26 @@
+{
+  "id": "truthset_1_1",
+  "type": "Adjacency",
+  "adjoinedSequences": [
+    {
+      "type": "SequenceLocation",
+      "sequenceReference": {
+        "type": "SequenceReference",
+        "id": "NC_000001.10",
+        "refgetAccession": "SQ.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU",
+        "residueAlphabet": "na"
+      },
+      "end": 87337011
+    },
+    {
+      "type": "SequenceLocation",
+      "sequenceReference": {
+        "type": "SequenceReference",
+        "refgetAccession": "SQ.-BOZ8Esn8J88qDwNiSEwUr5425UXdiGX",
+        "residueAlphabet": "na",
+        "id": "NC_000010.10"
+      },
+      "end": 36119127
+    }
+  ]
+}

--- a/examples/sequence_homology.json
+++ b/examples/sequence_homology.json
@@ -1,0 +1,26 @@
+{
+  "id": "sequence_homology",
+  "type": "Adjacency",
+  "adjoinedSequences": [
+    {
+      "type": "SequenceLocation",
+      "sequenceReference": {
+        "type": "SequenceReference",
+        "refgetAccession": "SQ.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU",
+        "residueAlphabet": "na",
+        "id": "NC_000001.10"
+      },
+      "end": [120, 126]
+    },
+    {
+      "type": "SequenceLocation",
+      "sequenceReference": {
+        "type": "SequenceReference",
+        "refgetAccession": "SQ.9KdcA9ZpY1Cpvxvg8bMSLYDUpsX6GDLO",
+        "residueAlphabet": "na",
+        "id": "NC_000002.11"
+      },
+      "start": [453, 459]
+    }
+  ]
+}

--- a/examples/simple_allele.json
+++ b/examples/simple_allele.json
@@ -1,11 +1,20 @@
-{'id': 'ga4gh:VA.ebezGL6HoAhtGJyVnB_mE5BH18ntKev4',
- 'type': 'Allele',
- 'digest': 'ebezGL6HoAhtGJyVnB_mE5BH18ntKev4',
- 'location': {'id': 'ga4gh:SL.JiLRuuyS5wefF_6-Vw7m3Yoqqb2YFkss',
-  'type': 'SequenceLocation',
-  'digest': 'JiLRuuyS5wefF_6-Vw7m3Yoqqb2YFkss',
-  'sequenceReference': {'type': 'SequenceReference',
-   'refgetAccession': 'SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI'},
-  'start': 80656488,
-  'end': 80656489},
- 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'T'}}
+{
+  "id": "simple_allele",
+  "type": "Allele",
+  "digest": "ebezGL6HoAhtGJyVnB_mE5BH18ntKev4",
+  "location": {
+    "id": "ga4gh:SL.JiLRuuyS5wefF_6-Vw7m3Yoqqb2YFkss",
+    "type": "SequenceLocation",
+    "digest": "JiLRuuyS5wefF_6-Vw7m3Yoqqb2YFkss",
+    "sequenceReference": {
+      "type": "SequenceReference",
+      "refgetAccession": "SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI"
+    },
+    "start": 80656488,
+    "end": 80656489
+  },
+  "state": {
+    "type": "LiteralSequenceExpression",
+    "sequence": "T"
+  }
+}

--- a/examples/simple_allele.json
+++ b/examples/simple_allele.json
@@ -1,0 +1,11 @@
+{'id': 'ga4gh:VA.ebezGL6HoAhtGJyVnB_mE5BH18ntKev4',
+ 'type': 'Allele',
+ 'digest': 'ebezGL6HoAhtGJyVnB_mE5BH18ntKev4',
+ 'location': {'id': 'ga4gh:SL.JiLRuuyS5wefF_6-Vw7m3Yoqqb2YFkss',
+  'type': 'SequenceLocation',
+  'digest': 'JiLRuuyS5wefF_6-Vw7m3Yoqqb2YFkss',
+  'sequenceReference': {'type': 'SequenceReference',
+   'refgetAccession': 'SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI'},
+  'start': 80656488,
+  'end': 80656489},
+ 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'T'}}

--- a/examples/simple_allele.yaml
+++ b/examples/simple_allele.yaml
@@ -1,0 +1,15 @@
+id: simple_allele
+type: Allele
+digest: ebezGL6HoAhtGJyVnB_mE5BH18ntKev4
+location:
+  id: ga4gh:SL.JiLRuuyS5wefF_6-Vw7m3Yoqqb2YFkss
+  type: SequenceLocation
+  digest: JiLRuuyS5wefF_6-Vw7m3Yoqqb2YFkss
+  sequenceReference:
+    type: SequenceReference
+    refgetAccession: SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI
+  start: 80656488
+  end: 80656489
+state:
+  type: LiteralSequenceExpression
+  sequence: T

--- a/examples/simple_breakpoint.json
+++ b/examples/simple_breakpoint.json
@@ -1,0 +1,26 @@
+{
+  "id": "simple_breakpoint",
+  "type": "Adjacency",
+  "adjoinedSequences": [
+    {
+      "type": "SequenceLocation",
+      "sequenceReference": {
+        "type": "SequenceReference",
+        "refgetAccession": "SQ.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU",
+        "residueAlphabet": "na",
+        "id": "NC_000001.10"
+      },
+      "end": 123
+    },
+    {
+      "type": "SequenceLocation",
+      "sequenceReference": {
+        "type": "SequenceReference",
+        "refgetAccession": "SQ.9KdcA9ZpY1Cpvxvg8bMSLYDUpsX6GDLO",
+        "residueAlphabet": "na",
+        "id": "NC_000002.11"
+      },
+      "start": 456
+    }
+  ]
+}

--- a/examples/simple_haplotype.json
+++ b/examples/simple_haplotype.json
@@ -1,0 +1,36 @@
+{
+  "id": "simple_haplotype",
+  "type": "CisPhasedBlock",
+  "members": [
+    {
+      "type": "Allele",
+      "location": {
+        "type": "SequenceLocation",
+        "start": 601,
+        "end": 602
+      },
+      "state": {
+        "type": "LiteralSequenceExpression",
+        "sequence": "C"
+      }
+    },
+    {
+      "type": "Allele",
+      "location": {
+        "type": "SequenceLocation",
+        "start": 701,
+        "end": 702
+      },
+      "state": {
+        "type": "LiteralSequenceExpression",
+        "sequence": "C"
+      }
+    }
+  ],
+  "sequenceReference": {
+    "type": "SequenceReference",
+    "refgetAccession": "SQ.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU",
+    "residueAlphabet": "na",
+    "id": "NC_000001.10"
+  }
+}

--- a/examples/sv_derivative_molecule.json
+++ b/examples/sv_derivative_molecule.json
@@ -1,0 +1,116 @@
+{
+  "id": "sv_derivative_molecule",
+  "type": "DerivativeMolecule",
+  "components": [
+    {
+      "id": "5-prime-terminus",
+      "type": "Terminus",
+      "location": {
+        "type": "SequenceLocation",
+        "sequenceReference": {
+          "type": "SequenceReference",
+          "refgetAccession": "SQ.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU",
+          "residueAlphabet": "na",
+          "id": "NC_000001.10"
+        },
+        "end": 123
+      }
+    },
+    {
+      "type": "TraversalBlock",
+      "orientation": "forward",
+      "component": {
+        "id": "adjacency1",
+        "type": "Adjacency",
+        "adjoinedSequences": [
+          {
+            "type": "SequenceLocation",
+            "sequenceReference": {
+              "type": "SequenceReference",
+              "refgetAccession": "SQ.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU",
+              "residueAlphabet": "na",
+              "id": "NC_000001.10"
+            },
+            "end": 123
+          },
+          {
+            "type": "SequenceLocation",
+            "sequenceReference": {
+              "type": "SequenceReference",
+              "refgetAccession": "SQ.9KdcA9ZpY1Cpvxvg8bMSLYDUpsX6GDLO",
+              "residueAlphabet": "na",
+              "id": "NC_000002.11"
+            },
+            "start": 500
+          }
+        ],
+        "linker": {
+          "type": "LiteralSequenceExpression",
+          "sequence": "GTC"
+        }
+      }
+    },
+    {
+      "type": "Allele",
+      "location": {
+        "type": "SequenceLocation",
+        "start": 601,
+        "end": 602,
+        "sequenceReference": {
+          "type": "SequenceReference",
+          "refgetAccession": "SQ.9KdcA9ZpY1Cpvxvg8bMSLYDUpsX6GDLO",
+          "residueAlphabet": "na",
+          "id": "NC_000002.11"
+        }
+      },
+      "state": {
+        "type": "LiteralSequenceExpression",
+        "sequence": "C"
+      }
+    },
+    {
+      "type": "TraversalBlock",
+      "orientation": "forward",
+      "component": {
+        "id": "adjacency2",
+        "type": "Adjacency",
+        "adjoinedSequences": [
+          {
+            "type": "SequenceLocation",
+            "sequenceReference": {
+              "type": "SequenceReference",
+              "refgetAccession": "SQ.9KdcA9ZpY1Cpvxvg8bMSLYDUpsX6GDLO",
+              "residueAlphabet": "na",
+              "id": "NC_000002.11"
+            },
+            "start": 15000
+          },
+          {
+            "type": "SequenceLocation",
+            "sequenceReference": {
+              "type": "SequenceReference",
+              "refgetAccession": "SQ.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU",
+              "residueAlphabet": "na",
+              "id": "NC_000001.10"
+            },
+            "end": 1000
+          }
+        ]
+      }
+    },
+    {
+      "id": "3-prime-terminus",
+      "type": "Terminus",
+      "location": {
+        "type": "SequenceLocation",
+        "sequenceReference": {
+          "type": "SequenceReference",
+          "refgetAccession": "SQ.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU",
+          "residueAlphabet": "na",
+          "id": "NC_000001.10"
+        },
+        "start": 1000
+      }
+    }
+  ]
+}

--- a/examples/terminal_breakend.json
+++ b/examples/terminal_breakend.json
@@ -1,0 +1,14 @@
+{
+  "id": "terminal_breakend",
+  "type": "Terminus",
+  "location": {
+    "type": "SequenceLocation",
+    "sequenceReference": {
+      "type": "SequenceReference",
+      "refgetAccession": "SQ.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU",
+      "residueAlphabet": "na",
+      "id": "NC_000001.10"
+    },
+    "end": 123
+  }
+}


### PR DESCRIPTION
Our goal in today's GKS Think Tank was to provide some VRS sample data objects for each type of variant.  Thanks to the data hiding in the examples directory, most of that work was already done!  

- We added a JSON object for each YAML object, so that implementers will have something to interact with while they develop their software
- We added a README file describing what these examples are, with a pointer to the test definitions file, where many of them are described
- We added an example simple allele, a SNV, which was one variant type not yet represented in the set.  (should this also go into the test data, for consistency?)
- To give these data visibility, we added notes to the bottom of the main README, and to the Quickstart page in readthedocs.