### PR TITLE
Fix swapped start/end in allele validation test

### DIFF
--- a/validation/alleles.yaml
+++ b/validation/alleles.yaml
@@ -203,8 +203,8 @@ Allele:
   - name: NC_000001.11:156114976:CGCTGTCGCCCA:CGCTGTCGCCCAGCCGGGTGCGCTGTCGCCCA
     in:
       location:
-        end: 156114976
-        start: 156114988
+        end: 156114988
+        start: 156114976
         sequenceReference:
           id: NC_000001.11
           type: SequenceReference


### PR DESCRIPTION
## Summary
- The 20bp insertion test case `NC_000001.11:156114976:CGCTGTCGCCCA:CGCTGTCGCCCAGCCGGGTGCGCTGTCGCCCA` in `validation/alleles.yaml` had `start=156114988` and `end=156114976` (start > end), which is invalid for interbase coordinates.
- Swaps them to `start=156114976`, `end=156114988`.

Found while running validation tests against a Rust VRS implementation.