### PR TITLE
Change VRS $id to v2 and regenerate JSON schemas

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "submodules/gks-core"]
 	path = submodules/gks-core
 	url = https://github.com/ga4gh/gks-core.git
-	branch = 1.2.0-ballot.2026-07
+	branch = v1

--- a/schema/vrs/json/Adjacency
+++ b/schema/vrs/json/Adjacency
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Adjacency",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/Adjacency",
    "title": "Adjacency",
    "type": "object",
    "maturity": "trial use",
@@ -53,7 +53,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Expression"
+            "$ref": "/ga4gh/schema/vrs/v2/json/Expression"
          }
       },
       "type": {
@@ -69,10 +69,10 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/RelativeSequenceLocation"
+                  "$ref": "/ga4gh/schema/vrs/v2/json/RelativeSequenceLocation"
                },
                {
-                  "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceLocation"
+                  "$ref": "/ga4gh/schema/vrs/v2/json/SequenceLocation"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -93,13 +93,13 @@
          "description": "The sequence found between adjoined sequences.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/LengthExpression"
+               "$ref": "/ga4gh/schema/vrs/v2/json/LengthExpression"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/LiteralSequenceExpression"
+               "$ref": "/ga4gh/schema/vrs/v2/json/LiteralSequenceExpression"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/ReferenceLengthExpression"
+               "$ref": "/ga4gh/schema/vrs/v2/json/ReferenceLengthExpression"
             }
          ]
       },

--- a/schema/vrs/json/Allele
+++ b/schema/vrs/json/Allele
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Allele",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/Allele",
    "title": "Allele",
    "type": "object",
    "maturity": "trial use",
@@ -53,7 +53,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Expression"
+            "$ref": "/ga4gh/schema/vrs/v2/json/Expression"
          }
       },
       "type": {
@@ -65,7 +65,7 @@
       "location": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceLocation"
+               "$ref": "/ga4gh/schema/vrs/v2/json/SequenceLocation"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -77,13 +77,13 @@
          "description": "An expression of the sequence state",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/LengthExpression"
+               "$ref": "/ga4gh/schema/vrs/v2/json/LengthExpression"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/LiteralSequenceExpression"
+               "$ref": "/ga4gh/schema/vrs/v2/json/LiteralSequenceExpression"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/ReferenceLengthExpression"
+               "$ref": "/ga4gh/schema/vrs/v2/json/ReferenceLengthExpression"
             }
          ]
       }

--- a/schema/vrs/json/CisPhasedBlock
+++ b/schema/vrs/json/CisPhasedBlock
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/CisPhasedBlock",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/CisPhasedBlock",
    "title": "CisPhasedBlock",
    "type": "object",
    "maturity": "trial use",
@@ -52,7 +52,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Expression"
+            "$ref": "/ga4gh/schema/vrs/v2/json/Expression"
          }
       },
       "type": {
@@ -69,7 +69,7 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Allele"
+                  "$ref": "/ga4gh/schema/vrs/v2/json/Allele"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -79,7 +79,7 @@
          "description": "A list of Alleles that are found in-cis on a shared molecule."
       },
       "sequenceReference": {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceReference",
+         "$ref": "/ga4gh/schema/vrs/v2/json/SequenceReference",
          "description": "An optional Sequence Reference on which all of the in-cis Alleles are found. When defined, this may be used to implicitly define the `sequenceReference` attribute for each of the CisPhasedBlock member Alleles."
       }
    },

--- a/schema/vrs/json/CopyNumberChange
+++ b/schema/vrs/json/CopyNumberChange
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/CopyNumberChange",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/CopyNumberChange",
    "title": "CopyNumberChange",
    "type": "object",
    "maturity": "draft",
@@ -53,7 +53,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Expression"
+            "$ref": "/ga4gh/schema/vrs/v2/json/Expression"
          }
       },
       "type": {
@@ -65,7 +65,7 @@
       "location": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceLocation"
+               "$ref": "/ga4gh/schema/vrs/v2/json/SequenceLocation"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"

--- a/schema/vrs/json/CopyNumberCount
+++ b/schema/vrs/json/CopyNumberCount
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/CopyNumberCount",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/CopyNumberCount",
    "title": "CopyNumberCount",
    "type": "object",
    "maturity": "trial use",
@@ -53,7 +53,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Expression"
+            "$ref": "/ga4gh/schema/vrs/v2/json/Expression"
          }
       },
       "type": {
@@ -65,7 +65,7 @@
       "location": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceLocation"
+               "$ref": "/ga4gh/schema/vrs/v2/json/SequenceLocation"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -76,7 +76,7 @@
       "copies": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Range"
+               "$ref": "/ga4gh/schema/vrs/v2/json/Range"
             },
             {
                "type": "integer"

--- a/schema/vrs/json/DerivativeMolecule
+++ b/schema/vrs/json/DerivativeMolecule
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/DerivativeMolecule",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/DerivativeMolecule",
    "title": "DerivativeMolecule",
    "type": "object",
    "maturity": "draft",
@@ -52,7 +52,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Expression"
+            "$ref": "/ga4gh/schema/vrs/v2/json/Expression"
          }
       },
       "type": {
@@ -68,16 +68,16 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Allele"
+                  "$ref": "/ga4gh/schema/vrs/v2/json/Allele"
                },
                {
-                  "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/CisPhasedBlock"
+                  "$ref": "/ga4gh/schema/vrs/v2/json/CisPhasedBlock"
                },
                {
-                  "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Terminus"
+                  "$ref": "/ga4gh/schema/vrs/v2/json/Terminus"
                },
                {
-                  "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/TraversalBlock"
+                  "$ref": "/ga4gh/schema/vrs/v2/json/TraversalBlock"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"

--- a/schema/vrs/json/Expression
+++ b/schema/vrs/json/Expression
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Expression",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/Expression",
    "title": "Expression",
    "type": "object",
    "maturity": "trial use",

--- a/schema/vrs/json/LengthExpression
+++ b/schema/vrs/json/LengthExpression
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/LengthExpression",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/LengthExpression",
    "title": "LengthExpression",
    "type": "object",
    "maturity": "draft",
@@ -53,7 +53,7 @@
          "description": "The length of the sequence.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Range"
+               "$ref": "/ga4gh/schema/vrs/v2/json/Range"
             },
             {
                "type": "integer"

--- a/schema/vrs/json/LiteralSequenceExpression
+++ b/schema/vrs/json/LiteralSequenceExpression
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/LiteralSequenceExpression",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/LiteralSequenceExpression",
    "title": "LiteralSequenceExpression",
    "type": "object",
    "maturity": "trial use",
@@ -50,7 +50,7 @@
          "default": "LiteralSequenceExpression"
       },
       "sequence": {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/sequenceString",
+         "$ref": "/ga4gh/schema/vrs/v2/json/sequenceString",
          "description": "the literal sequence"
       }
    },

--- a/schema/vrs/json/Location
+++ b/schema/vrs/json/Location
@@ -1,16 +1,16 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Location",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/Location",
    "title": "Location",
    "type": "object",
    "maturity": "trial use",
    "description": "A contiguous segment of a biological sequence.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/RelativeSequenceLocation"
+         "$ref": "/ga4gh/schema/vrs/v2/json/RelativeSequenceLocation"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceLocation"
+         "$ref": "/ga4gh/schema/vrs/v2/json/SequenceLocation"
       }
    ],
    "discriminator": {

--- a/schema/vrs/json/MolecularVariation
+++ b/schema/vrs/json/MolecularVariation
@@ -1,28 +1,28 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/MolecularVariation",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/MolecularVariation",
    "title": "MolecularVariation",
    "type": "object",
    "maturity": "trial use",
    "description": "A variation on a contiguous molecule.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Adjacency"
+         "$ref": "/ga4gh/schema/vrs/v2/json/Adjacency"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Allele"
+         "$ref": "/ga4gh/schema/vrs/v2/json/Allele"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/CisPhasedBlock"
+         "$ref": "/ga4gh/schema/vrs/v2/json/CisPhasedBlock"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/DerivativeMolecule"
+         "$ref": "/ga4gh/schema/vrs/v2/json/DerivativeMolecule"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/RelativeAllele"
+         "$ref": "/ga4gh/schema/vrs/v2/json/RelativeAllele"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Terminus"
+         "$ref": "/ga4gh/schema/vrs/v2/json/Terminus"
       }
    ],
    "discriminator": {

--- a/schema/vrs/json/Range
+++ b/schema/vrs/json/Range
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Range",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/Range",
    "title": "Range",
    "type": "array",
    "maturity": "trial use",

--- a/schema/vrs/json/ReferenceLengthExpression
+++ b/schema/vrs/json/ReferenceLengthExpression
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/ReferenceLengthExpression",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/ReferenceLengthExpression",
    "title": "ReferenceLengthExpression",
    "type": "object",
    "maturity": "trial use",
@@ -53,7 +53,7 @@
       "length": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Range"
+               "$ref": "/ga4gh/schema/vrs/v2/json/Range"
             },
             {
                "type": "integer"
@@ -62,7 +62,7 @@
          "description": "The number of residues in the expressed sequence."
       },
       "sequence": {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/sequenceString",
+         "$ref": "/ga4gh/schema/vrs/v2/json/sequenceString",
          "description": "the literal sequence encoded by the Reference Length Expression."
       },
       "repeatSubunitLength": {

--- a/schema/vrs/json/RelativeAllele
+++ b/schema/vrs/json/RelativeAllele
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/RelativeAllele",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/RelativeAllele",
    "title": "RelativeAllele",
    "type": "object",
    "maturity": "draft",
@@ -54,7 +54,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Expression"
+            "$ref": "/ga4gh/schema/vrs/v2/json/Expression"
          }
       },
       "type": {
@@ -67,13 +67,13 @@
          "description": "The state of the RelativeAllele as expressed on the mapped sequence. This will differ from the base state when mapping to a reverse complement sequence, commonly observed when representing the state on transcripts mapped to the \"negative strand\" of a chromosome.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/LengthExpression"
+               "$ref": "/ga4gh/schema/vrs/v2/json/LengthExpression"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/LiteralSequenceExpression"
+               "$ref": "/ga4gh/schema/vrs/v2/json/LiteralSequenceExpression"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/ReferenceLengthExpression"
+               "$ref": "/ga4gh/schema/vrs/v2/json/ReferenceLengthExpression"
             }
          ]
       },
@@ -81,13 +81,13 @@
          "description": "The state of the RelativeAllele as expressed on the base sequence.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/LengthExpression"
+               "$ref": "/ga4gh/schema/vrs/v2/json/LengthExpression"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/LiteralSequenceExpression"
+               "$ref": "/ga4gh/schema/vrs/v2/json/LiteralSequenceExpression"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/ReferenceLengthExpression"
+               "$ref": "/ga4gh/schema/vrs/v2/json/ReferenceLengthExpression"
             }
          ]
       },
@@ -95,7 +95,7 @@
          "description": "The relative location at which the baseState and mappedState are expressed.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/RelativeSequenceLocation"
+               "$ref": "/ga4gh/schema/vrs/v2/json/RelativeSequenceLocation"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"

--- a/schema/vrs/json/RelativeSequenceLocation
+++ b/schema/vrs/json/RelativeSequenceLocation
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/RelativeSequenceLocation",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/RelativeSequenceLocation",
    "title": "RelativeSequenceLocation",
    "type": "object",
    "maturity": "draft",
@@ -59,7 +59,7 @@
          "description": "An absolute location on a sequence.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceLocation"
+               "$ref": "/ga4gh/schema/vrs/v2/json/SequenceLocation"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -70,7 +70,7 @@
          "description": "A location relative to an offset on a mapped sequence.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceOffsetLocation"
+               "$ref": "/ga4gh/schema/vrs/v2/json/SequenceOffsetLocation"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"

--- a/schema/vrs/json/SequenceExpression
+++ b/schema/vrs/json/SequenceExpression
@@ -1,19 +1,19 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceExpression",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/SequenceExpression",
    "title": "SequenceExpression",
    "type": "object",
    "maturity": "trial use",
    "description": "An expression describing a sequence.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/LengthExpression"
+         "$ref": "/ga4gh/schema/vrs/v2/json/LengthExpression"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/LiteralSequenceExpression"
+         "$ref": "/ga4gh/schema/vrs/v2/json/LiteralSequenceExpression"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/ReferenceLengthExpression"
+         "$ref": "/ga4gh/schema/vrs/v2/json/ReferenceLengthExpression"
       }
    ],
    "discriminator": {

--- a/schema/vrs/json/SequenceLocation
+++ b/schema/vrs/json/SequenceLocation
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceLocation",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/SequenceLocation",
    "title": "SequenceLocation",
    "type": "object",
    "maturity": "trial use",
@@ -59,7 +59,7 @@
       "sequenceReference": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceReference"
+               "$ref": "/ga4gh/schema/vrs/v2/json/SequenceReference"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -70,7 +70,7 @@
       "start": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Range"
+               "$ref": "/ga4gh/schema/vrs/v2/json/Range"
             },
             {
                "type": "integer"
@@ -81,7 +81,7 @@
       "end": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Range"
+               "$ref": "/ga4gh/schema/vrs/v2/json/Range"
             },
             {
                "type": "integer"
@@ -91,7 +91,7 @@
       },
       "sequence": {
          "description": "The literal sequence encoded by the `sequenceReference` at these coordinates.",
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/sequenceString"
+         "$ref": "/ga4gh/schema/vrs/v2/json/sequenceString"
       }
    },
    "required": [

--- a/schema/vrs/json/SequenceOffsetLocation
+++ b/schema/vrs/json/SequenceOffsetLocation
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceOffsetLocation",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/SequenceOffsetLocation",
    "title": "SequenceOffsetLocation",
    "type": "object",
    "maturity": "draft",
@@ -57,7 +57,7 @@
          "description": "A sequence reference that has been mapped from which a relative location is defined.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceReference"
+               "$ref": "/ga4gh/schema/vrs/v2/json/SequenceReference"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -80,7 +80,7 @@
          "description": "The start offset, in inter-residue coordinates, from the anchor realization selected by anchorOrientation on the sequenceReference.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Range"
+               "$ref": "/ga4gh/schema/vrs/v2/json/Range"
             },
             {
                "type": "integer"
@@ -91,7 +91,7 @@
          "description": "The end offset, in inter-residue coordinates, from the anchor realization selected by anchorOrientation on the sequenceReference.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Range"
+               "$ref": "/ga4gh/schema/vrs/v2/json/Range"
             },
             {
                "type": "integer"

--- a/schema/vrs/json/SequenceReference
+++ b/schema/vrs/json/SequenceReference
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceReference",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/SequenceReference",
    "title": "SequenceReference",
    "type": "object",
    "maturity": "trial use",
@@ -63,7 +63,7 @@
          ]
       },
       "sequence": {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/sequenceString",
+         "$ref": "/ga4gh/schema/vrs/v2/json/sequenceString",
          "description": "A sequenceString that is a literal representation of the referenced sequence."
       },
       "moleculeType": {

--- a/schema/vrs/json/SystemicVariation
+++ b/schema/vrs/json/SystemicVariation
@@ -1,16 +1,16 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SystemicVariation",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/SystemicVariation",
    "title": "SystemicVariation",
    "type": "object",
    "maturity": "trial use",
    "description": "A Variation of multiple molecules in the context of a system, e.g. a genome, sample, or homologous chromosomes.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/CopyNumberChange"
+         "$ref": "/ga4gh/schema/vrs/v2/json/CopyNumberChange"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/CopyNumberCount"
+         "$ref": "/ga4gh/schema/vrs/v2/json/CopyNumberCount"
       }
    ],
    "discriminator": {

--- a/schema/vrs/json/Terminus
+++ b/schema/vrs/json/Terminus
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Terminus",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/Terminus",
    "title": "Terminus",
    "type": "object",
    "maturity": "draft",
@@ -52,7 +52,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Expression"
+            "$ref": "/ga4gh/schema/vrs/v2/json/Expression"
          }
       },
       "type": {
@@ -64,10 +64,10 @@
       "location": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/RelativeSequenceLocation"
+               "$ref": "/ga4gh/schema/vrs/v2/json/RelativeSequenceLocation"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/SequenceLocation"
+               "$ref": "/ga4gh/schema/vrs/v2/json/SequenceLocation"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"

--- a/schema/vrs/json/TraversalBlock
+++ b/schema/vrs/json/TraversalBlock
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/TraversalBlock",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/TraversalBlock",
    "title": "TraversalBlock",
    "type": "object",
    "maturity": "draft",
@@ -54,7 +54,7 @@
          "description": "The unoriented molecular variation component.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Adjacency"
+               "$ref": "/ga4gh/schema/vrs/v2/json/Adjacency"
             }
          ]
       },

--- a/schema/vrs/json/Variation
+++ b/schema/vrs/json/Variation
@@ -1,34 +1,34 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Variation",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/Variation",
    "title": "Variation",
    "type": "object",
    "maturity": "trial use",
    "description": "A representation of the state of one or more biomolecules.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Adjacency"
+         "$ref": "/ga4gh/schema/vrs/v2/json/Adjacency"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Allele"
+         "$ref": "/ga4gh/schema/vrs/v2/json/Allele"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/CisPhasedBlock"
+         "$ref": "/ga4gh/schema/vrs/v2/json/CisPhasedBlock"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/CopyNumberChange"
+         "$ref": "/ga4gh/schema/vrs/v2/json/CopyNumberChange"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/CopyNumberCount"
+         "$ref": "/ga4gh/schema/vrs/v2/json/CopyNumberCount"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/DerivativeMolecule"
+         "$ref": "/ga4gh/schema/vrs/v2/json/DerivativeMolecule"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/RelativeAllele"
+         "$ref": "/ga4gh/schema/vrs/v2/json/RelativeAllele"
       },
       {
-         "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Terminus"
+         "$ref": "/ga4gh/schema/vrs/v2/json/Terminus"
       }
    ],
    "discriminator": {

--- a/schema/vrs/json/residue
+++ b/schema/vrs/json/residue
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/residue",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/residue",
    "title": "residue",
    "type": "string",
    "maturity": "trial use",

--- a/schema/vrs/json/sequenceString
+++ b/schema/vrs/json/sequenceString
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/sequenceString",
+   "$id": "https://w3id.org/ga4gh/schema/vrs/v2/json/sequenceString",
    "title": "sequenceString",
    "type": "string",
    "maturity": "trial use",

--- a/schema/vrs/vrs-source.yaml
+++ b/schema/vrs/vrs-source.yaml
@@ -9,7 +9,7 @@
 
 # https://json-schema.org/understanding-json-schema/reference/schema.html
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/vrs-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/vrs/v2/vrs-source.yaml"
 title: "GA4GH-VRS-Definitions"
 type: object
 strict: true


### PR DESCRIPTION
## Summary
Updates the VRS schema `$id` values to the `v2` path and regenerates the JSON schemas accordingly.

## Changes
- Change VRS `$id` to v2
- Regenerate JSON schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)