### PR TITLE
docs: categorize 2.1.0 release log by SemVer bucket

### DIFF
--- a/docs/source/releases/2.1.rst
+++ b/docs/source/releases/2.1.rst
@@ -4,21 +4,61 @@
 2.1.0
 @@@@@
 
-* docs: remove broken refs in releases by @jsstevenson in https://github.com/ga4gh/vrs/pull/647
-* docs: fix a few warnings, remove anonymous entries from search results by @jsstevenson in https://github.com/ga4gh/vrs/pull/646
-* chore: bump gks-core from 1.0.0 to 1.1.0 by @korikuzma in https://github.com/ga4gh/vrs/pull/664
-* docs: add `ConceptSet` and reorder changelog by @korikuzma in https://github.com/ga4gh/vrs/pull/666
-* docs: auto-update copyright year by @jsstevenson in https://github.com/ga4gh/vrs/pull/673
-* docs: fix refs, add warnings check to CI/CD by @jsstevenson in https://github.com/ga4gh/vrs/pull/671
-* docs: fix orphaned pages showing up in search results by @jsstevenson in https://github.com/ga4gh/vrs/pull/672
-* feat: add Intronic Positions by @korikuzma in https://github.com/ga4gh/vrs/pull/675
-* test: add tests for ensuring correct properties by @korikuzma in https://github.com/ga4gh/vrs/pull/686
-* fix: update type and ga4gh.inherent for intron positions by @korikuzma in https://github.com/ga4gh/vrs/pull/684
-* fix: use correct img.shields.io link for docs badge by @korikuzma in https://github.com/ga4gh/vrs/pull/685
-* #690: Quick start guidance by @brendanreardon in https://github.com/ga4gh/vrs/pull/693
-* minor cosmetic and doc updates by @larrybabb in https://github.com/ga4gh/vrs/pull/698
-* chore: add citation file by @jsstevenson in https://github.com/ga4gh/vrs/pull/701
-* Revise normalization algorithm to select smallest factor by @ahwagner in https://github.com/ga4gh/vrs/pull/700
-* docs: add RelativeAllele example and normalization rules by @larrybabb in https://github.com/ga4gh/vrs/pull/689
-* chore: remove this old unused TODO file by @jsstevenson in https://github.com/ga4gh/vrs/pull/703
-* Fix inconsistent seed_length formatting in normalization docs by @harshitmishra00182-ops in https://github.com/ga4gh/vrs/pull/702
+Version 2.1.0 of the GA4GH Variation Representation Specification (VRS)
+adds support for intronic positions, including new classes for relative sequence
+locations and relative alleles. It also revises the normalization algorithm for
+ambiguous insertions to select the smallest repeat-unit factor rather than the
+greatest, changing the normalized (and therefore digested) representation of
+affected trial-use Allele instances.
+
+Minor Version Increment
+#######################
+
+  * revises the :ref:`normalization` algorithm for ambiguous insertions to
+    select the *smallest* repeat-unit factor rather than the greatest,
+    changing the normalized (and therefore digested) representation of
+    affected trial-use :ref:`Allele` instances by @ahwagner in
+    https://github.com/ga4gh/vrs/pull/700
+
+Patch Version Increment
+#######################
+
+  * adds :ref:`RelativeSequenceLocation`, :ref:`SequenceOffsetLocation`, and
+    :ref:`RelativeAllele` to support intronic positions, all at draft
+    maturity, by @korikuzma in https://github.com/ga4gh/vrs/pull/675
+  * fixes ``type`` and ``ga4gh.inherent`` for the draft intronic position
+    classes by @korikuzma in https://github.com/ga4gh/vrs/pull/684
+  * adds tests for ensuring correct properties by @korikuzma in
+    https://github.com/ga4gh/vrs/pull/686
+  * adds a :ref:`RelativeAllele` example and intronic-position normalization
+    rules by @larrybabb in https://github.com/ga4gh/vrs/pull/689
+  * fixes inconsistent ``seed_length`` formatting in normalization docs by
+    @harshitmishra00182-ops in https://github.com/ga4gh/vrs/pull/702
+  * bumps the GKS-core submodule from 1.0.0 to 1.1.0 and, later, to
+    1.2.0-ballot.2026-07; the only classes touched upstream
+    (:ref:`MappableConcept`, :ref:`ConceptSet`) are not inherited or embedded
+    by any VRS class, so neither bump carries a data-compatibility impact
+    into VRS by @korikuzma and @ahwagner in
+    https://github.com/ga4gh/vrs/pull/664
+  * removes broken refs in releases by @jsstevenson in
+    https://github.com/ga4gh/vrs/pull/647
+  * fixes a few warnings, removes anonymous entries from search results by
+    @jsstevenson in https://github.com/ga4gh/vrs/pull/646
+  * adds :ref:`ConceptSet` and reorders changelog by @korikuzma in
+    https://github.com/ga4gh/vrs/pull/666
+  * auto-updates copyright year by @jsstevenson in
+    https://github.com/ga4gh/vrs/pull/673
+  * fixes refs, adds warnings check to CI/CD by @jsstevenson in
+    https://github.com/ga4gh/vrs/pull/671
+  * fixes orphaned pages showing up in search results by @jsstevenson in
+    https://github.com/ga4gh/vrs/pull/672
+  * fixes the img.shields.io link for the docs badge by @korikuzma in
+    https://github.com/ga4gh/vrs/pull/685
+  * adds quick start guidance by @brendanreardon in
+    https://github.com/ga4gh/vrs/pull/693
+  * minor cosmetic and doc updates by @larrybabb in
+    https://github.com/ga4gh/vrs/pull/698
+  * adds a citation file by @jsstevenson in
+    https://github.com/ga4gh/vrs/pull/701
+  * removes an old unused TODO file by @jsstevenson in
+    https://github.com/ga4gh/vrs/pull/703

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -4,7 +4,9 @@ Releases
 .. note::
 
     VRS follows the :ref:`maturity-model`, which includes our standard
-    Work Stream practices for :ref:`versioning`.
+    Work Stream practices for :ref:`versioning`. Major/Minor/Patch version
+    increments below are assigned per the GA4GH TASC "Technical
+    Specification Development" policy.
 
     All planned and ongoing work may be found on the `VRS Roadmap
     <https://github.com/orgs/ga4gh/projects/12>`__.


### PR DESCRIPTION
Revises the in-progress 2.1.0 release notes to follow the GA4GH TASC
Major/Minor/Patch categorization convention instead of a flat PR list:

- Adds a descriptive summary paragraph under the 2.1.0 heading calling out
  the notable new features (intronic positions, normalization algorithm
  revision), even though the intronic-position classes only land at
  draft/patch maturity.
- **Minor**: the normalization algorithm revision (#700) is a
  backwards-incompatible change to a trial-use product feature (changes the
  normalized/digested representation of affected `Allele` instances), which
  is what justifies the 2.1.0 minor version bump.
- **Patch**: everything else, including the intronic-position classes (all
  draft maturity) and the gks-core submodule bumps, which were traced
  upstream and confirmed to touch only `MappableConcept`/`ConceptSet` —
  neither of which is inherited or embedded by any VRS class, so no
  data-compatibility impact propagates into VRS.
- Names the GA4GH TASC "Technical Specification Development" policy
  explicitly in the `releases/index.rst` note, since the existing
  maturity-model/versioning refs didn't name it anywhere.

Docs build validated locally (`sphinx-build -b html`), no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)