### PR TITLE
docs: fix RFC 8785 section citation for control character codes

### DIFF
--- a/docs/source/conventions/computed_identifiers.rst
+++ b/docs/source/conventions/computed_identifiers.rst
@@ -125,7 +125,7 @@ The second step is to JSON serialize the message content following the
       <https://datatracker.ietf.org/doc/html/rfc8785#section-3.2.1>`__
     * order all keys by Unicode Character Set values
     * use predefined JSON control character codes when available,
-      as defined in `RFC8785§3.2.2.1 <https://datatracker.ietf.org/doc/html/rfc8785#section-3.2.2.2>`__
+      as defined in `RFC8785§3.2.2.2 <https://datatracker.ietf.org/doc/html/rfc8785#section-3.2.2.2>`__
 
 The criteria for the digest serialization method was that it must be
 relatively easy and reliable to implement in any common computer


### PR DESCRIPTION
`computed_identifiers.rst` cited RFC 8785 §3.2.2.1 for predefined JSON control character escape codes, but the adjacent link already pointed to §3.2.2.2, which is the correct section (§3.2.2.2 is "Serialization of Strings"; §3.2.2.1 is "Serialization of Literals" — `null`/`true`/`false`). Fixes the label to match the link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)